### PR TITLE
Remove `.not_nil!` from `exec` instrumentation of `HTTP:Client`

### DIFF
--- a/src/opentelemetry/instrumentation/crystal/http_client.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_client.cr
@@ -128,7 +128,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_CLIENT") do
             end
 
             response
-          end.not_nil!
+          end
         end
       end
     end


### PR DESCRIPTION
This `.not_nil!` could create runtime errors where the return of a block passed to `HTTP::Client#exec` was intended to be nil.

Dependent on https://github.com/wyhaines/opentelemetry-api.cr/pull/7 to make the types all check out.