### PR TITLE
Kh.add crystal redis 20220504

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       run: apt-get -qy install libsqlite3-dev
     - name: Install dependencies
       run: shards install
+    - name: Crystal Version
+      run: crystal --version
     - name: Run tests
       run: crystal spec --stats --progress --error-trace -D DEBUG -v
     - name: Run Ameba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install dependencies
       run: shards install
     - name: Run tests
-      run: crystal spec -t -s
+      run: crystal spec --stats --progress --error-trace -D DEBUG -v
     - name: Run Ameba
       run: bin/ameba

--- a/licenses/JGASKINS_REDIS_LICENSE
+++ b/licenses/JGASKINS_REDIS_LICENSE
@@ -1,0 +1,27 @@
+This license covers the pieces of Jaime Gaskins Redis library that are
+substantially duplicated here. Primarily, this is the specs for the
+corresponding instrumentation.
+
+-----
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Jaime Gaskins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/licenses/STEFANWILLE_REDIS_LICENSE
+++ b/licenses/STEFANWILLE_REDIS_LICENSE
@@ -1,0 +1,27 @@
+This license covers the pieces of Stefan Wille's Redis library that are
+substantially duplicated here. Primarily, this is the specs for the
+corresponding instrumentation.
+
+-----
+
+Copyright (c) 2015 Stefan Wille
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/shard.yml
+++ b/shard.yml
@@ -23,8 +23,8 @@ development_dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3
   # Only one of these can be enabled, since they sit in the exact same namespace.
-  # redis:
-  #   github: stefanwille/crystal-redis
-  #   branch: master
   redis:
-   github: jgaskins/redis
+    github: stefanwille/crystal-redis
+    branch: master
+  # redis:
+  #  github: jgaskins/redis

--- a/shard.yml
+++ b/shard.yml
@@ -22,6 +22,9 @@ development_dependencies:
     version: ~> 1.0.0
   sqlite3:
     github: crystal-lang/crystal-sqlite3
+  # Only one of these can be enabled, since they sit in the exact same namespace.
   redis:
     github: stefanwille/crystal-redis
     branch: master
+  #redis:
+  #  github: jgaskins/redis

--- a/shard.yml
+++ b/shard.yml
@@ -22,3 +22,6 @@ development_dependencies:
     version: ~> 1.0.0
   sqlite3:
     github: crystal-lang/crystal-sqlite3
+  redis:
+    github: stefanwille/crystal-redis
+    branch: master

--- a/shard.yml
+++ b/shard.yml
@@ -23,8 +23,8 @@ development_dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3
   # Only one of these can be enabled, since they sit in the exact same namespace.
+  # redis:
+  #   github: stefanwille/crystal-redis
+  #   branch: master
   redis:
-    github: stefanwille/crystal-redis
-    branch: master
-  #redis:
-  #  github: jgaskins/redis
+   github: jgaskins/redis

--- a/spec/instrumentation/crystal_http_server_spec.cr
+++ b/spec/instrumentation/crystal_http_server_spec.cr
@@ -47,17 +47,7 @@ describe HTTP::Server, tags: ["HTTP::Server"] do
       sleep((rand() * 100) / 1000)
     end
 
-    memory.rewind
-    strings = memory.gets_to_end
-    json_finder = FindJson.new(strings)
-
-    traces = [] of JSON::Any
-    while json = json_finder.pull_json
-      traces << JSON.parse(json)
-    end
-
-    client_traces = traces.select { |t| t["spans"][0]["kind"] == 3 }
-    server_traces = traces.reject { |t| t["spans"][0]["kind"] == 3 }
+    client_traces, server_traces = FindJson.from_io(memory)
 
     {% begin %}
     {% if flag? :DEBUG %}

--- a/spec/instrumentation/crystal_http_websocket_spec.cr
+++ b/spec/instrumentation/crystal_http_websocket_spec.cr
@@ -516,17 +516,7 @@ describe HTTP::WebSocket, tags: ["HTTP::WebSocket"] do
 
     sleep 1
 
-    memory.rewind
-    strings = memory.gets_to_end
-    json_finder = FindJson.new(strings)
-
-    traces = [] of JSON::Any
-    while json = json_finder.pull_json
-      traces << JSON.parse(json)
-    end
-
-    client_traces = traces.select { |t| t["spans"][0]["kind"] == 3 }
-    server_traces = traces.reject { |t| t["spans"][0]["kind"] == 3 }
+    client_traces, server_traces = FindJson.from_io(memory)
 
     {% begin %}
     {% if flag? :DEBUG %}

--- a/spec/instrumentation/jgaskins_redis_spec.cr
+++ b/spec/instrumentation/jgaskins_redis_spec.cr
@@ -3,433 +3,435 @@ require "./jgaskins_redis_spec_helper"
 
 if_defined?(Redis::VERSION) do
   if_version?(Redis, :>=, "0.3.1") do
+
+    {% p "GITHUB, YOU ARE DRUNK" %}
     # Do not use DB slot 15. That's used as the secondary DB for testing the ability
     # to use DBs other than 0.
-    redis_uri = URI.parse("redis:///")
-    redis = Redis::Client.new(uri: redis_uri)
-
-    private def random_key
-      UUID.random.to_s
-    end
-
-    private macro test(msg, &block)
-      it {{msg}} do
-        key = random_key
-
-        begin
-          {{yield}}
-        ensure
-          redis.del key
-        end
-      end
-    end
-
-    memory = IO::Memory.new
-
-    describe Redis::Client do
-      before_all do
-        OpenTelemetry.configure do |config|
-          config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
-          config.service_version = OpenTelemetry::VERSION
-          config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
-        end
-      end
-
-      after_each do
-        memory.clear
-      end
-
-      it "can set, get, and delete keys" do
-        known_key = random_key
-
-        begin
-          redis.get(random_key).should eq nil
-          redis.set(known_key, "hello")
-          redis.get(known_key).should eq "hello"
-          redis.del(known_key).should eq 1
-          redis.del(known_key).should eq 0
-          redis.get(known_key).should eq nil
-
-          client_traces, server_traces = FindJson.from_io(memory)
-        ensure
-          redis.del known_key
-        end
-      end
-
-      test "can set expiration timestamps on keys" do
-        redis.set key, "foo", ex: 10.milliseconds.from_now
-        redis.get(key).should eq "foo"
-        sleep 10.milliseconds
-        redis.get(key).should eq nil
-      end
-
-      test "can expire key after a specified number of seconds" do
-        redis.set key, "foo"
-        redis.expire key, 1
-        sleep 1.5.seconds
-        redis.get(key).should eq nil
-      end
-
-      test "can expire key at a given timestamp" do
-        redis.set key, "foo"
-        redis.expireat key, 1.second.from_now
-        sleep 1.second
-        redis.get(key).should eq nil
-      end
-
-      test "can expire key after a specified number of milliseconds" do
-        redis.set key, "foo"
-        redis.pexpire key, 10
-        sleep 100.milliseconds
-        redis.get(key).should eq nil
-      end
-
-      test "can expire key at a given milliseconds-timestamp" do
-        redis.set key, "foo"
-        redis.pexpireat key, 10.milliseconds.from_now
-        sleep 100.milliseconds
-        redis.get(key).should eq nil
-      end
-
-      test "can returns the remaining time to live of a key that has a timeout in seconds" do
-        redis.set key, "foo", ex: 1
-        redis.ttl(key).should eq 1
-      end
-
-      test "can returns the remaining time to live of a key that has a timeout in milliseconds" do
-        redis.set key, "foo", px: 10
-        result = redis.pttl(key)
-        result.should be <= 10
-        result.should be >= 1
-      end
-
-      test "can set a key only if it does not exist" do
-        redis.set(key, "foo", nx: true).should eq "OK"
-        redis.set(key, "foo", nx: true).should eq nil
-      end
-
-      test "can set a key only if it does exist" do
-        redis.set(key, "foo", xx: true).should eq nil
-        redis.set key, "foo"
-        redis.set(key, "foo", xx: true).should eq "OK"
-      end
-
-      it "can get the list of keys" do
-        key = random_key
-
-        begin
-          redis.set key, "yep"
-          redis.keys.includes?(key).should eq true
-        ensure
-          redis.del key
-        end
-      end
-
-      it "can increment and decrement" do
-        key = random_key
-
-        begin
-          redis.incr(key).should eq 1
-          redis.incr(key).should eq 2
-          redis.get(key).should eq "2"
-          redis.decr(key).should eq 1
-          redis.decr(key).should eq 0
-          redis.get(key).should eq "0"
-
-          redis.incrby(key, 2).should eq 2
-          redis.incrby(key, 3).should eq 5
-          redis.decrby(key, 2).should eq 3
-          redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
-        ensure
-          redis.del key
-        end
-      end
-
-      describe "sets" do
-        it "can add and remove members of a set" do
-          key = random_key
-
-          begin
-            redis.sadd(key, "a").should eq 1
-            redis.sadd(key, "a").should eq 0
-            redis.smembers(key).should eq %w[a]
-
-            redis.sadd key, "b"
-            redis.smembers(key).includes?("a").should eq true
-            redis.smembers(key).includes?("b").should eq true
-
-            redis.srem key, "a"
-            redis.smembers(key).includes?("a").should eq false
-            redis.smembers(key).includes?("b").should eq true
-          ensure
-            redis.del key
-          end
-        end
-
-        test "can check whether a set has a value" do
-          redis.sismember(key, "a").should eq 0
-          redis.sadd key, "a"
-          redis.sismember(key, "a").should eq 1
-        end
-
-        test "can find the difference in 2 sets" do
-          first = key
-          second = random_key
-
-          redis.sadd first, "a", "b", "c"
-          redis.sadd second, "b", "c", "d"
-
-          # Just the elements of first that are not in second
-          redis.sdiff(first, second).should eq %w[a]
-        ensure
-          redis.del second if second
-        end
-
-        test "can find the intersection of multiple sets" do
-          first = key
-          second = random_key
-          third = random_key
-
-          redis.sadd first, "a", "b", "c"
-          redis.sadd second, "b", "c", "d"
-          redis.sadd third, "c", "d", "e"
-
-          redis.sinter(first, second, third).should eq %w[c]
-        ensure
-          redis.del second, third if second && third
-        end
-
-        test "can determine the number of members of a set" do
-          redis.sadd key, "a"
-          redis.scard(key).should eq 1
-          redis.sadd key, "b", "c"
-          redis.scard(key).should eq 3
-        end
-      end
-
-      it "can pipeline commands" do
-        key = random_key
-
-        begin
-          first_incr = Redis::Future.new
-          second_incr = Redis::Future.new
-          first_decr = Redis::Future.new
-          second_decr = Redis::Future.new
-
-          redis.pipeline do |redis|
-            first_incr = redis.incr key
-            second_incr = redis.incr key
-
-            first_decr = redis.decr key
-            second_decr = redis.decr key
-          end.should eq [1, 2, 1, 0]
-
-          first_incr.value.should eq 1
-          second_incr.value.should eq 2
-          first_decr.value.should eq 1
-          second_decr.value.should eq 0
-        ensure
-          redis.del key
-        end
-      end
-
-      test "checking for existence of keys" do
-        redis.exists(key).should eq 0
-
-        redis.incr key
-        redis.exists(key).should eq 1
-
-        redis.del key
-        redis.exists(key).should eq 0
-      end
-
-      it "handles exceptions while pipelining" do
-        key = random_key
-
-        begin
-          redis.pipeline do |redis|
-            redis.incr key
-            redis.incr key
-            raise "lol"
-          end
-        rescue
-          redis.get(key).should eq "2"
-        ensure
-          redis.del key
-        end
-      end
-
-      it "can use different Redis DBs" do
-        secondary_uri = redis_uri.dup
-        secondary_uri.path = "/15"
-        secondary_db = Redis::Client.new(uri: secondary_uri)
-        key = random_key
-
-        begin
-          redis.set key, "42"
-          redis.get(key).should eq "42"
-          secondary_db.get(key).should eq nil
-        ensure
-          redis.del key
-          secondary_db.close
-        end
-      end
-
-      describe "streams" do
-        it "can use streams" do
-          key = random_key
-
-          begin
-            # entry_id = redis.xadd key, "*", {"foo" => "bar"}
-            entry_id = redis.xadd key, "*", foo: "bar"
-            range = redis.xrange(key, "-", "+")
-            range.size.should eq 1
-            range.each do |result|
-              id, data = result.as(Array)
-              id.as(String).should eq entry_id
-              data.should eq %w[foo bar]
-            end
-          ensure
-            redis.del key
-          end
-        end
-
-        test "can cap streams" do
-          redis.pipeline do |pipe|
-            11.times { pipe.xadd key, "*", maxlen: "10", foo: "bar" }
-          end
-
-          redis.xlen(key).should eq 10
-        end
-
-        test "can approximately cap streams" do
-          redis.pipeline do |pipe|
-            2_000.times { pipe.xadd key, "*", maxlen: {"~", "10"}, foo: "bar" }
-          end
-
-          redis.xlen(key).should be <= 100
-        end
-
-        it "can consume streams" do
-          key = "my-stream"
-          group = "my-group"
-
-          begin
-            entry_id = redis.xadd key, "*", foo: "bar"
-            # Create a group to consume this stream starting at the beginning
-            redis.xgroup "create", key, group, "0"
-            consumer_id = UUID.random.to_s
-
-            result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
-          rescue ex
-            pp ex
-            raise ex
-          ensure
-            redis.xgroup "destroy", key, group
-            redis.del key
-          end
-        end
-      end
-
-      it "can use transactions" do
-        key = random_key
-
-        begin
-          redis.multi do |redis|
-            redis.set key, "yep"
-            redis.discard
-
-            redis.get "fuck"
-          end.should be_empty
-
-          redis.get(key).should eq nil
-
-          _, nope, _, yep = redis.multi do |redis|
-            redis.set key, "nope"
-            redis.get key
-            redis.set key, "yep"
-            redis.get key
-          end
-
-          nope.should eq "nope"
-          yep.should eq "yep"
-
-          redis.get(key).should eq "yep"
-          redis.del key
-
-          begin
-            redis.multi do |redis|
-              redis.set key, "lol"
-
-              raise "oops"
-            ensure
-              redis.get(key).should eq nil
-            end
-          rescue
-          end
-
-          # Ensure we're still in the same state
-          redis.get(key).should eq nil
-          # Ensure we can still set the key
-          redis.set key, "yep"
-          redis.get(key).should eq "yep"
-        ensure
-          redis.del key
-        end
-      end
-
-      it "works with lists" do
-        key = random_key
-
-        begin
-          spawn do
-            sleep 10.milliseconds
-            redis.lpush key, "omg", "lol", "wtf", "bbq"
-          end
-          redis.brpop(key, timeout: 1).should eq [key, "omg"]
-          redis.brpop(key, timeout: "1").should eq [key, "lol"]
-          redis.brpop(key, timeout: 1.second).should eq [key, "wtf"]
-          redis.brpop(key, timeout: 1.0).should eq [key, "bbq"]
-        ensure
-          redis.del key
-        end
-
-        left = random_key
-        right = random_key
-
-        begin
-          redis.lpush left, "foo"
-          redis.rpoplpush left, right
-          redis.rpop(right).should eq "foo"
-        ensure
-          redis.del left, right
-        end
-      end
-
-      it "can publish and subscribe" do
-        ready = false
-        spawn do
-          until ready
-            Fiber.yield
-          end
-          # Publishes happen on other connections
-          spawn redis.publish "foo", "unsub"
-          spawn redis.publish "bar", "unsub"
-        end
-
-        redis.subscribe "foo", "bar" do |subscription, conn|
-          subscription.on_message do |channel, message|
-            if message == "unsub"
-              conn.unsubscribe channel
-            end
-          end
-
-          subscription.on_subscribe do |channel, count|
-            # Only set ready if *both* subscriptions have gone through
-            ready = true if count == 2
-          end
-        end
-      end
-    end
+    # redis_uri = URI.parse("redis:///")
+    # redis = Redis::Client.new(uri: redis_uri)
+
+    # private def random_key
+    #   UUID.random.to_s
+    # end
+
+    # private macro test(msg, &block)
+    #   it {{msg}} do
+    #     key = random_key
+
+    #     begin
+    #       {{yield}}
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+    # end
+
+    # memory = IO::Memory.new
+
+    # describe Redis::Client do
+    #   before_all do
+    #     OpenTelemetry.configure do |config|
+    #       config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
+    #       config.service_version = OpenTelemetry::VERSION
+    #       config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
+    #     end
+    #   end
+
+    #   after_each do
+    #     memory.clear
+    #   end
+
+    #   it "can set, get, and delete keys" do
+    #     known_key = random_key
+
+    #     begin
+    #       redis.get(random_key).should eq nil
+    #       redis.set(known_key, "hello")
+    #       redis.get(known_key).should eq "hello"
+    #       redis.del(known_key).should eq 1
+    #       redis.del(known_key).should eq 0
+    #       redis.get(known_key).should eq nil
+
+    #       client_traces, server_traces = FindJson.from_io(memory)
+    #     ensure
+    #       redis.del known_key
+    #     end
+    #   end
+
+    #   test "can set expiration timestamps on keys" do
+    #     redis.set key, "foo", ex: 10.milliseconds.from_now
+    #     redis.get(key).should eq "foo"
+    #     sleep 10.milliseconds
+    #     redis.get(key).should eq nil
+    #   end
+
+    #   test "can expire key after a specified number of seconds" do
+    #     redis.set key, "foo"
+    #     redis.expire key, 1
+    #     sleep 1.5.seconds
+    #     redis.get(key).should eq nil
+    #   end
+
+    #   test "can expire key at a given timestamp" do
+    #     redis.set key, "foo"
+    #     redis.expireat key, 1.second.from_now
+    #     sleep 1.second
+    #     redis.get(key).should eq nil
+    #   end
+
+    #   test "can expire key after a specified number of milliseconds" do
+    #     redis.set key, "foo"
+    #     redis.pexpire key, 10
+    #     sleep 100.milliseconds
+    #     redis.get(key).should eq nil
+    #   end
+
+    #   test "can expire key at a given milliseconds-timestamp" do
+    #     redis.set key, "foo"
+    #     redis.pexpireat key, 10.milliseconds.from_now
+    #     sleep 100.milliseconds
+    #     redis.get(key).should eq nil
+    #   end
+
+    #   test "can returns the remaining time to live of a key that has a timeout in seconds" do
+    #     redis.set key, "foo", ex: 1
+    #     redis.ttl(key).should eq 1
+    #   end
+
+    #   test "can returns the remaining time to live of a key that has a timeout in milliseconds" do
+    #     redis.set key, "foo", px: 10
+    #     result = redis.pttl(key)
+    #     result.should be <= 10
+    #     result.should be >= 1
+    #   end
+
+    #   test "can set a key only if it does not exist" do
+    #     redis.set(key, "foo", nx: true).should eq "OK"
+    #     redis.set(key, "foo", nx: true).should eq nil
+    #   end
+
+    #   test "can set a key only if it does exist" do
+    #     redis.set(key, "foo", xx: true).should eq nil
+    #     redis.set key, "foo"
+    #     redis.set(key, "foo", xx: true).should eq "OK"
+    #   end
+
+    #   it "can get the list of keys" do
+    #     key = random_key
+
+    #     begin
+    #       redis.set key, "yep"
+    #       redis.keys.includes?(key).should eq true
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+
+    #   it "can increment and decrement" do
+    #     key = random_key
+
+    #     begin
+    #       redis.incr(key).should eq 1
+    #       redis.incr(key).should eq 2
+    #       redis.get(key).should eq "2"
+    #       redis.decr(key).should eq 1
+    #       redis.decr(key).should eq 0
+    #       redis.get(key).should eq "0"
+
+    #       redis.incrby(key, 2).should eq 2
+    #       redis.incrby(key, 3).should eq 5
+    #       redis.decrby(key, 2).should eq 3
+    #       redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+
+    #   describe "sets" do
+    #     it "can add and remove members of a set" do
+    #       key = random_key
+
+    #       begin
+    #         redis.sadd(key, "a").should eq 1
+    #         redis.sadd(key, "a").should eq 0
+    #         redis.smembers(key).should eq %w[a]
+
+    #         redis.sadd key, "b"
+    #         redis.smembers(key).includes?("a").should eq true
+    #         redis.smembers(key).includes?("b").should eq true
+
+    #         redis.srem key, "a"
+    #         redis.smembers(key).includes?("a").should eq false
+    #         redis.smembers(key).includes?("b").should eq true
+    #       ensure
+    #         redis.del key
+    #       end
+    #     end
+
+    #     test "can check whether a set has a value" do
+    #       redis.sismember(key, "a").should eq 0
+    #       redis.sadd key, "a"
+    #       redis.sismember(key, "a").should eq 1
+    #     end
+
+    #     test "can find the difference in 2 sets" do
+    #       first = key
+    #       second = random_key
+
+    #       redis.sadd first, "a", "b", "c"
+    #       redis.sadd second, "b", "c", "d"
+
+    #       # Just the elements of first that are not in second
+    #       redis.sdiff(first, second).should eq %w[a]
+    #     ensure
+    #       redis.del second if second
+    #     end
+
+    #     test "can find the intersection of multiple sets" do
+    #       first = key
+    #       second = random_key
+    #       third = random_key
+
+    #       redis.sadd first, "a", "b", "c"
+    #       redis.sadd second, "b", "c", "d"
+    #       redis.sadd third, "c", "d", "e"
+
+    #       redis.sinter(first, second, third).should eq %w[c]
+    #     ensure
+    #       redis.del second, third if second && third
+    #     end
+
+    #     test "can determine the number of members of a set" do
+    #       redis.sadd key, "a"
+    #       redis.scard(key).should eq 1
+    #       redis.sadd key, "b", "c"
+    #       redis.scard(key).should eq 3
+    #     end
+    #   end
+
+    #   it "can pipeline commands" do
+    #     key = random_key
+
+    #     begin
+    #       first_incr = Redis::Future.new
+    #       second_incr = Redis::Future.new
+    #       first_decr = Redis::Future.new
+    #       second_decr = Redis::Future.new
+
+    #       redis.pipeline do |redis|
+    #         first_incr = redis.incr key
+    #         second_incr = redis.incr key
+
+    #         first_decr = redis.decr key
+    #         second_decr = redis.decr key
+    #       end.should eq [1, 2, 1, 0]
+
+    #       first_incr.value.should eq 1
+    #       second_incr.value.should eq 2
+    #       first_decr.value.should eq 1
+    #       second_decr.value.should eq 0
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+
+    #   test "checking for existence of keys" do
+    #     redis.exists(key).should eq 0
+
+    #     redis.incr key
+    #     redis.exists(key).should eq 1
+
+    #     redis.del key
+    #     redis.exists(key).should eq 0
+    #   end
+
+    #   it "handles exceptions while pipelining" do
+    #     key = random_key
+
+    #     begin
+    #       redis.pipeline do |redis|
+    #         redis.incr key
+    #         redis.incr key
+    #         raise "lol"
+    #       end
+    #     rescue
+    #       redis.get(key).should eq "2"
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+
+    #   it "can use different Redis DBs" do
+    #     secondary_uri = redis_uri.dup
+    #     secondary_uri.path = "/15"
+    #     secondary_db = Redis::Client.new(uri: secondary_uri)
+    #     key = random_key
+
+    #     begin
+    #       redis.set key, "42"
+    #       redis.get(key).should eq "42"
+    #       secondary_db.get(key).should eq nil
+    #     ensure
+    #       redis.del key
+    #       secondary_db.close
+    #     end
+    #   end
+
+    #   describe "streams" do
+    #     it "can use streams" do
+    #       key = random_key
+
+    #       begin
+    #         # entry_id = redis.xadd key, "*", {"foo" => "bar"}
+    #         entry_id = redis.xadd key, "*", foo: "bar"
+    #         range = redis.xrange(key, "-", "+")
+    #         range.size.should eq 1
+    #         range.each do |result|
+    #           id, data = result.as(Array)
+    #           id.as(String).should eq entry_id
+    #           data.should eq %w[foo bar]
+    #         end
+    #       ensure
+    #         redis.del key
+    #       end
+    #     end
+
+    #     test "can cap streams" do
+    #       redis.pipeline do |pipe|
+    #         11.times { pipe.xadd key, "*", maxlen: "10", foo: "bar" }
+    #       end
+
+    #       redis.xlen(key).should eq 10
+    #     end
+
+    #     test "can approximately cap streams" do
+    #       redis.pipeline do |pipe|
+    #         2_000.times { pipe.xadd key, "*", maxlen: {"~", "10"}, foo: "bar" }
+    #       end
+
+    #       redis.xlen(key).should be <= 100
+    #     end
+
+    #     it "can consume streams" do
+    #       key = "my-stream"
+    #       group = "my-group"
+
+    #       begin
+    #         entry_id = redis.xadd key, "*", foo: "bar"
+    #         # Create a group to consume this stream starting at the beginning
+    #         redis.xgroup "create", key, group, "0"
+    #         consumer_id = UUID.random.to_s
+
+    #         result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
+    #       rescue ex
+    #         pp ex
+    #         raise ex
+    #       ensure
+    #         redis.xgroup "destroy", key, group
+    #         redis.del key
+    #       end
+    #     end
+    #   end
+
+    #   it "can use transactions" do
+    #     key = random_key
+
+    #     begin
+    #       redis.multi do |redis|
+    #         redis.set key, "yep"
+    #         redis.discard
+
+    #         redis.get "fuck"
+    #       end.should be_empty
+
+    #       redis.get(key).should eq nil
+
+    #       _, nope, _, yep = redis.multi do |redis|
+    #         redis.set key, "nope"
+    #         redis.get key
+    #         redis.set key, "yep"
+    #         redis.get key
+    #       end
+
+    #       nope.should eq "nope"
+    #       yep.should eq "yep"
+
+    #       redis.get(key).should eq "yep"
+    #       redis.del key
+
+    #       begin
+    #         redis.multi do |redis|
+    #           redis.set key, "lol"
+
+    #           raise "oops"
+    #         ensure
+    #           redis.get(key).should eq nil
+    #         end
+    #       rescue
+    #       end
+
+    #       # Ensure we're still in the same state
+    #       redis.get(key).should eq nil
+    #       # Ensure we can still set the key
+    #       redis.set key, "yep"
+    #       redis.get(key).should eq "yep"
+    #     ensure
+    #       redis.del key
+    #     end
+    #   end
+
+    #   it "works with lists" do
+    #     key = random_key
+
+    #     begin
+    #       spawn do
+    #         sleep 10.milliseconds
+    #         redis.lpush key, "omg", "lol", "wtf", "bbq"
+    #       end
+    #       redis.brpop(key, timeout: 1).should eq [key, "omg"]
+    #       redis.brpop(key, timeout: "1").should eq [key, "lol"]
+    #       redis.brpop(key, timeout: 1.second).should eq [key, "wtf"]
+    #       redis.brpop(key, timeout: 1.0).should eq [key, "bbq"]
+    #     ensure
+    #       redis.del key
+    #     end
+
+    #     left = random_key
+    #     right = random_key
+
+    #     begin
+    #       redis.lpush left, "foo"
+    #       redis.rpoplpush left, right
+    #       redis.rpop(right).should eq "foo"
+    #     ensure
+    #       redis.del left, right
+    #     end
+    #   end
+
+    #   it "can publish and subscribe" do
+    #     ready = false
+    #     spawn do
+    #       until ready
+    #         Fiber.yield
+    #       end
+    #       # Publishes happen on other connections
+    #       spawn redis.publish "foo", "unsub"
+    #       spawn redis.publish "bar", "unsub"
+    #     end
+
+    #     redis.subscribe "foo", "bar" do |subscription, conn|
+    #       subscription.on_message do |channel, message|
+    #         if message == "unsub"
+    #           conn.unsubscribe channel
+    #         end
+    #       end
+
+    #       subscription.on_subscribe do |channel, count|
+    #         # Only set ready if *both* subscriptions have gone through
+    #         ready = true if count == 2
+    #       end
+    #     end
+    #   end
+    # end
   end
 end

--- a/spec/instrumentation/jgaskins_redis_spec.cr
+++ b/spec/instrumentation/jgaskins_redis_spec.cr
@@ -4,10 +4,10 @@ require "./jgaskins_redis_spec_helper"
 if_defined?(Redis::VERSION) do
   if_version?(Redis, :>=, "0.3.1") do
 
-    Do not use DB slot 15. That's used as the secondary DB for testing the ability
-    to use DBs other than 0.
-    redis_uri = URI.parse("redis:///")
-    redis = Redis::Client.new(uri: redis_uri)
+  # Do not use DB slot 15. That's used as the secondary DB for testing the ability
+  # to use DBs other than 0.
+  # redis_uri = URI.parse("redis:///")
+  # redis = Redis::Client.new(uri: redis_uri)
 
     private def random_key
       UUID.random.to_s

--- a/spec/instrumentation/jgaskins_redis_spec.cr
+++ b/spec/instrumentation/jgaskins_redis_spec.cr
@@ -51,7 +51,7 @@ if_defined?(Redis::VERSION) do
           redis.del(known_key).should eq 0
           redis.get(known_key).should eq nil
 
-          client_traces, server_traces = FindJson.from_io(memory)
+          FindJson.from_io(memory)
         ensure
           redis.del known_key
         end
@@ -316,14 +316,13 @@ if_defined?(Redis::VERSION) do
           group = "my-group"
 
           begin
-            entry_id = redis.xadd key, "*", foo: "bar"
+            _entry_id = redis.xadd key, "*", foo: "bar"
             # Create a group to consume this stream starting at the beginning
             redis.xgroup "create", key, group, "0"
             consumer_id = UUID.random.to_s
 
-            result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
+            _result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
           rescue ex
-            pp ex
             raise ex
           ensure
             redis.xgroup "destroy", key, group
@@ -425,7 +424,7 @@ if_defined?(Redis::VERSION) do
             end
           end
 
-          subscription.on_subscribe do |channel, count|
+          subscription.on_subscribe do |_channel, count|
             # Only set ready if *both* subscriptions have gone through
             ready = true if count == 2
           end

--- a/spec/instrumentation/jgaskins_redis_spec.cr
+++ b/spec/instrumentation/jgaskins_redis_spec.cr
@@ -4,434 +4,433 @@ require "./jgaskins_redis_spec_helper"
 if_defined?(Redis::VERSION) do
   if_version?(Redis, :>=, "0.3.1") do
 
-    {% p "GITHUB, YOU ARE DRUNK" %}
-    # Do not use DB slot 15. That's used as the secondary DB for testing the ability
-    # to use DBs other than 0.
-    # redis_uri = URI.parse("redis:///")
-    # redis = Redis::Client.new(uri: redis_uri)
-
-    # private def random_key
-    #   UUID.random.to_s
-    # end
-
-    # private macro test(msg, &block)
-    #   it {{msg}} do
-    #     key = random_key
-
-    #     begin
-    #       {{yield}}
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-    # end
-
-    # memory = IO::Memory.new
-
-    # describe Redis::Client do
-    #   before_all do
-    #     OpenTelemetry.configure do |config|
-    #       config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
-    #       config.service_version = OpenTelemetry::VERSION
-    #       config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
-    #     end
-    #   end
-
-    #   after_each do
-    #     memory.clear
-    #   end
-
-    #   it "can set, get, and delete keys" do
-    #     known_key = random_key
-
-    #     begin
-    #       redis.get(random_key).should eq nil
-    #       redis.set(known_key, "hello")
-    #       redis.get(known_key).should eq "hello"
-    #       redis.del(known_key).should eq 1
-    #       redis.del(known_key).should eq 0
-    #       redis.get(known_key).should eq nil
-
-    #       client_traces, server_traces = FindJson.from_io(memory)
-    #     ensure
-    #       redis.del known_key
-    #     end
-    #   end
-
-    #   test "can set expiration timestamps on keys" do
-    #     redis.set key, "foo", ex: 10.milliseconds.from_now
-    #     redis.get(key).should eq "foo"
-    #     sleep 10.milliseconds
-    #     redis.get(key).should eq nil
-    #   end
-
-    #   test "can expire key after a specified number of seconds" do
-    #     redis.set key, "foo"
-    #     redis.expire key, 1
-    #     sleep 1.5.seconds
-    #     redis.get(key).should eq nil
-    #   end
-
-    #   test "can expire key at a given timestamp" do
-    #     redis.set key, "foo"
-    #     redis.expireat key, 1.second.from_now
-    #     sleep 1.second
-    #     redis.get(key).should eq nil
-    #   end
-
-    #   test "can expire key after a specified number of milliseconds" do
-    #     redis.set key, "foo"
-    #     redis.pexpire key, 10
-    #     sleep 100.milliseconds
-    #     redis.get(key).should eq nil
-    #   end
-
-    #   test "can expire key at a given milliseconds-timestamp" do
-    #     redis.set key, "foo"
-    #     redis.pexpireat key, 10.milliseconds.from_now
-    #     sleep 100.milliseconds
-    #     redis.get(key).should eq nil
-    #   end
-
-    #   test "can returns the remaining time to live of a key that has a timeout in seconds" do
-    #     redis.set key, "foo", ex: 1
-    #     redis.ttl(key).should eq 1
-    #   end
-
-    #   test "can returns the remaining time to live of a key that has a timeout in milliseconds" do
-    #     redis.set key, "foo", px: 10
-    #     result = redis.pttl(key)
-    #     result.should be <= 10
-    #     result.should be >= 1
-    #   end
-
-    #   test "can set a key only if it does not exist" do
-    #     redis.set(key, "foo", nx: true).should eq "OK"
-    #     redis.set(key, "foo", nx: true).should eq nil
-    #   end
-
-    #   test "can set a key only if it does exist" do
-    #     redis.set(key, "foo", xx: true).should eq nil
-    #     redis.set key, "foo"
-    #     redis.set(key, "foo", xx: true).should eq "OK"
-    #   end
-
-    #   it "can get the list of keys" do
-    #     key = random_key
-
-    #     begin
-    #       redis.set key, "yep"
-    #       redis.keys.includes?(key).should eq true
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-
-    #   it "can increment and decrement" do
-    #     key = random_key
-
-    #     begin
-    #       redis.incr(key).should eq 1
-    #       redis.incr(key).should eq 2
-    #       redis.get(key).should eq "2"
-    #       redis.decr(key).should eq 1
-    #       redis.decr(key).should eq 0
-    #       redis.get(key).should eq "0"
-
-    #       redis.incrby(key, 2).should eq 2
-    #       redis.incrby(key, 3).should eq 5
-    #       redis.decrby(key, 2).should eq 3
-    #       redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-
-    #   describe "sets" do
-    #     it "can add and remove members of a set" do
-    #       key = random_key
-
-    #       begin
-    #         redis.sadd(key, "a").should eq 1
-    #         redis.sadd(key, "a").should eq 0
-    #         redis.smembers(key).should eq %w[a]
-
-    #         redis.sadd key, "b"
-    #         redis.smembers(key).includes?("a").should eq true
-    #         redis.smembers(key).includes?("b").should eq true
-
-    #         redis.srem key, "a"
-    #         redis.smembers(key).includes?("a").should eq false
-    #         redis.smembers(key).includes?("b").should eq true
-    #       ensure
-    #         redis.del key
-    #       end
-    #     end
-
-    #     test "can check whether a set has a value" do
-    #       redis.sismember(key, "a").should eq 0
-    #       redis.sadd key, "a"
-    #       redis.sismember(key, "a").should eq 1
-    #     end
-
-    #     test "can find the difference in 2 sets" do
-    #       first = key
-    #       second = random_key
-
-    #       redis.sadd first, "a", "b", "c"
-    #       redis.sadd second, "b", "c", "d"
-
-    #       # Just the elements of first that are not in second
-    #       redis.sdiff(first, second).should eq %w[a]
-    #     ensure
-    #       redis.del second if second
-    #     end
-
-    #     test "can find the intersection of multiple sets" do
-    #       first = key
-    #       second = random_key
-    #       third = random_key
-
-    #       redis.sadd first, "a", "b", "c"
-    #       redis.sadd second, "b", "c", "d"
-    #       redis.sadd third, "c", "d", "e"
-
-    #       redis.sinter(first, second, third).should eq %w[c]
-    #     ensure
-    #       redis.del second, third if second && third
-    #     end
-
-    #     test "can determine the number of members of a set" do
-    #       redis.sadd key, "a"
-    #       redis.scard(key).should eq 1
-    #       redis.sadd key, "b", "c"
-    #       redis.scard(key).should eq 3
-    #     end
-    #   end
-
-    #   it "can pipeline commands" do
-    #     key = random_key
-
-    #     begin
-    #       first_incr = Redis::Future.new
-    #       second_incr = Redis::Future.new
-    #       first_decr = Redis::Future.new
-    #       second_decr = Redis::Future.new
-
-    #       redis.pipeline do |redis|
-    #         first_incr = redis.incr key
-    #         second_incr = redis.incr key
-
-    #         first_decr = redis.decr key
-    #         second_decr = redis.decr key
-    #       end.should eq [1, 2, 1, 0]
-
-    #       first_incr.value.should eq 1
-    #       second_incr.value.should eq 2
-    #       first_decr.value.should eq 1
-    #       second_decr.value.should eq 0
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-
-    #   test "checking for existence of keys" do
-    #     redis.exists(key).should eq 0
-
-    #     redis.incr key
-    #     redis.exists(key).should eq 1
-
-    #     redis.del key
-    #     redis.exists(key).should eq 0
-    #   end
-
-    #   it "handles exceptions while pipelining" do
-    #     key = random_key
-
-    #     begin
-    #       redis.pipeline do |redis|
-    #         redis.incr key
-    #         redis.incr key
-    #         raise "lol"
-    #       end
-    #     rescue
-    #       redis.get(key).should eq "2"
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-
-    #   it "can use different Redis DBs" do
-    #     secondary_uri = redis_uri.dup
-    #     secondary_uri.path = "/15"
-    #     secondary_db = Redis::Client.new(uri: secondary_uri)
-    #     key = random_key
-
-    #     begin
-    #       redis.set key, "42"
-    #       redis.get(key).should eq "42"
-    #       secondary_db.get(key).should eq nil
-    #     ensure
-    #       redis.del key
-    #       secondary_db.close
-    #     end
-    #   end
-
-    #   describe "streams" do
-    #     it "can use streams" do
-    #       key = random_key
-
-    #       begin
-    #         # entry_id = redis.xadd key, "*", {"foo" => "bar"}
-    #         entry_id = redis.xadd key, "*", foo: "bar"
-    #         range = redis.xrange(key, "-", "+")
-    #         range.size.should eq 1
-    #         range.each do |result|
-    #           id, data = result.as(Array)
-    #           id.as(String).should eq entry_id
-    #           data.should eq %w[foo bar]
-    #         end
-    #       ensure
-    #         redis.del key
-    #       end
-    #     end
-
-    #     test "can cap streams" do
-    #       redis.pipeline do |pipe|
-    #         11.times { pipe.xadd key, "*", maxlen: "10", foo: "bar" }
-    #       end
-
-    #       redis.xlen(key).should eq 10
-    #     end
-
-    #     test "can approximately cap streams" do
-    #       redis.pipeline do |pipe|
-    #         2_000.times { pipe.xadd key, "*", maxlen: {"~", "10"}, foo: "bar" }
-    #       end
-
-    #       redis.xlen(key).should be <= 100
-    #     end
-
-    #     it "can consume streams" do
-    #       key = "my-stream"
-    #       group = "my-group"
-
-    #       begin
-    #         entry_id = redis.xadd key, "*", foo: "bar"
-    #         # Create a group to consume this stream starting at the beginning
-    #         redis.xgroup "create", key, group, "0"
-    #         consumer_id = UUID.random.to_s
-
-    #         result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
-    #       rescue ex
-    #         pp ex
-    #         raise ex
-    #       ensure
-    #         redis.xgroup "destroy", key, group
-    #         redis.del key
-    #       end
-    #     end
-    #   end
-
-    #   it "can use transactions" do
-    #     key = random_key
-
-    #     begin
-    #       redis.multi do |redis|
-    #         redis.set key, "yep"
-    #         redis.discard
-
-    #         redis.get "fuck"
-    #       end.should be_empty
-
-    #       redis.get(key).should eq nil
-
-    #       _, nope, _, yep = redis.multi do |redis|
-    #         redis.set key, "nope"
-    #         redis.get key
-    #         redis.set key, "yep"
-    #         redis.get key
-    #       end
-
-    #       nope.should eq "nope"
-    #       yep.should eq "yep"
-
-    #       redis.get(key).should eq "yep"
-    #       redis.del key
-
-    #       begin
-    #         redis.multi do |redis|
-    #           redis.set key, "lol"
-
-    #           raise "oops"
-    #         ensure
-    #           redis.get(key).should eq nil
-    #         end
-    #       rescue
-    #       end
-
-    #       # Ensure we're still in the same state
-    #       redis.get(key).should eq nil
-    #       # Ensure we can still set the key
-    #       redis.set key, "yep"
-    #       redis.get(key).should eq "yep"
-    #     ensure
-    #       redis.del key
-    #     end
-    #   end
-
-    #   it "works with lists" do
-    #     key = random_key
-
-    #     begin
-    #       spawn do
-    #         sleep 10.milliseconds
-    #         redis.lpush key, "omg", "lol", "wtf", "bbq"
-    #       end
-    #       redis.brpop(key, timeout: 1).should eq [key, "omg"]
-    #       redis.brpop(key, timeout: "1").should eq [key, "lol"]
-    #       redis.brpop(key, timeout: 1.second).should eq [key, "wtf"]
-    #       redis.brpop(key, timeout: 1.0).should eq [key, "bbq"]
-    #     ensure
-    #       redis.del key
-    #     end
-
-    #     left = random_key
-    #     right = random_key
-
-    #     begin
-    #       redis.lpush left, "foo"
-    #       redis.rpoplpush left, right
-    #       redis.rpop(right).should eq "foo"
-    #     ensure
-    #       redis.del left, right
-    #     end
-    #   end
-
-    #   it "can publish and subscribe" do
-    #     ready = false
-    #     spawn do
-    #       until ready
-    #         Fiber.yield
-    #       end
-    #       # Publishes happen on other connections
-    #       spawn redis.publish "foo", "unsub"
-    #       spawn redis.publish "bar", "unsub"
-    #     end
-
-    #     redis.subscribe "foo", "bar" do |subscription, conn|
-    #       subscription.on_message do |channel, message|
-    #         if message == "unsub"
-    #           conn.unsubscribe channel
-    #         end
-    #       end
-
-    #       subscription.on_subscribe do |channel, count|
-    #         # Only set ready if *both* subscriptions have gone through
-    #         ready = true if count == 2
-    #       end
-    #     end
-    #   end
-    # end
+    Do not use DB slot 15. That's used as the secondary DB for testing the ability
+    to use DBs other than 0.
+    redis_uri = URI.parse("redis:///")
+    redis = Redis::Client.new(uri: redis_uri)
+
+    private def random_key
+      UUID.random.to_s
+    end
+
+    private macro test(msg, &block)
+      it {{msg}} do
+        key = random_key
+
+        begin
+          {{yield}}
+        ensure
+          redis.del key
+        end
+      end
+    end
+
+    memory = IO::Memory.new
+
+    describe Redis::Client do
+      before_all do
+        OpenTelemetry.configure do |config|
+          config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
+          config.service_version = OpenTelemetry::VERSION
+          config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
+        end
+      end
+
+      after_each do
+        memory.clear
+      end
+
+      it "can set, get, and delete keys" do
+        known_key = random_key
+
+        begin
+          redis.get(random_key).should eq nil
+          redis.set(known_key, "hello")
+          redis.get(known_key).should eq "hello"
+          redis.del(known_key).should eq 1
+          redis.del(known_key).should eq 0
+          redis.get(known_key).should eq nil
+
+          client_traces, server_traces = FindJson.from_io(memory)
+        ensure
+          redis.del known_key
+        end
+      end
+
+      test "can set expiration timestamps on keys" do
+        redis.set key, "foo", ex: 10.milliseconds.from_now
+        redis.get(key).should eq "foo"
+        sleep 10.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key after a specified number of seconds" do
+        redis.set key, "foo"
+        redis.expire key, 1
+        sleep 1.5.seconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key at a given timestamp" do
+        redis.set key, "foo"
+        redis.expireat key, 1.second.from_now
+        sleep 1.second
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key after a specified number of milliseconds" do
+        redis.set key, "foo"
+        redis.pexpire key, 10
+        sleep 100.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key at a given milliseconds-timestamp" do
+        redis.set key, "foo"
+        redis.pexpireat key, 10.milliseconds.from_now
+        sleep 100.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can returns the remaining time to live of a key that has a timeout in seconds" do
+        redis.set key, "foo", ex: 1
+        redis.ttl(key).should eq 1
+      end
+
+      test "can returns the remaining time to live of a key that has a timeout in milliseconds" do
+        redis.set key, "foo", px: 10
+        result = redis.pttl(key)
+        result.should be <= 10
+        result.should be >= 1
+      end
+
+      test "can set a key only if it does not exist" do
+        redis.set(key, "foo", nx: true).should eq "OK"
+        redis.set(key, "foo", nx: true).should eq nil
+      end
+
+      test "can set a key only if it does exist" do
+        redis.set(key, "foo", xx: true).should eq nil
+        redis.set key, "foo"
+        redis.set(key, "foo", xx: true).should eq "OK"
+      end
+
+      it "can get the list of keys" do
+        key = random_key
+
+        begin
+          redis.set key, "yep"
+          redis.keys.includes?(key).should eq true
+        ensure
+          redis.del key
+        end
+      end
+
+      it "can increment and decrement" do
+        key = random_key
+
+        begin
+          redis.incr(key).should eq 1
+          redis.incr(key).should eq 2
+          redis.get(key).should eq "2"
+          redis.decr(key).should eq 1
+          redis.decr(key).should eq 0
+          redis.get(key).should eq "0"
+
+          redis.incrby(key, 2).should eq 2
+          redis.incrby(key, 3).should eq 5
+          redis.decrby(key, 2).should eq 3
+          redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
+        ensure
+          redis.del key
+        end
+      end
+
+      describe "sets" do
+        it "can add and remove members of a set" do
+          key = random_key
+
+          begin
+            redis.sadd(key, "a").should eq 1
+            redis.sadd(key, "a").should eq 0
+            redis.smembers(key).should eq %w[a]
+
+            redis.sadd key, "b"
+            redis.smembers(key).includes?("a").should eq true
+            redis.smembers(key).includes?("b").should eq true
+
+            redis.srem key, "a"
+            redis.smembers(key).includes?("a").should eq false
+            redis.smembers(key).includes?("b").should eq true
+          ensure
+            redis.del key
+          end
+        end
+
+        test "can check whether a set has a value" do
+          redis.sismember(key, "a").should eq 0
+          redis.sadd key, "a"
+          redis.sismember(key, "a").should eq 1
+        end
+
+        test "can find the difference in 2 sets" do
+          first = key
+          second = random_key
+
+          redis.sadd first, "a", "b", "c"
+          redis.sadd second, "b", "c", "d"
+
+          # Just the elements of first that are not in second
+          redis.sdiff(first, second).should eq %w[a]
+        ensure
+          redis.del second if second
+        end
+
+        test "can find the intersection of multiple sets" do
+          first = key
+          second = random_key
+          third = random_key
+
+          redis.sadd first, "a", "b", "c"
+          redis.sadd second, "b", "c", "d"
+          redis.sadd third, "c", "d", "e"
+
+          redis.sinter(first, second, third).should eq %w[c]
+        ensure
+          redis.del second, third if second && third
+        end
+
+        test "can determine the number of members of a set" do
+          redis.sadd key, "a"
+          redis.scard(key).should eq 1
+          redis.sadd key, "b", "c"
+          redis.scard(key).should eq 3
+        end
+      end
+
+      it "can pipeline commands" do
+        key = random_key
+
+        begin
+          first_incr = Redis::Future.new
+          second_incr = Redis::Future.new
+          first_decr = Redis::Future.new
+          second_decr = Redis::Future.new
+
+          redis.pipeline do |redis|
+            first_incr = redis.incr key
+            second_incr = redis.incr key
+
+            first_decr = redis.decr key
+            second_decr = redis.decr key
+          end.should eq [1, 2, 1, 0]
+
+          first_incr.value.should eq 1
+          second_incr.value.should eq 2
+          first_decr.value.should eq 1
+          second_decr.value.should eq 0
+        ensure
+          redis.del key
+        end
+      end
+
+      test "checking for existence of keys" do
+        redis.exists(key).should eq 0
+
+        redis.incr key
+        redis.exists(key).should eq 1
+
+        redis.del key
+        redis.exists(key).should eq 0
+      end
+
+      it "handles exceptions while pipelining" do
+        key = random_key
+
+        begin
+          redis.pipeline do |redis|
+            redis.incr key
+            redis.incr key
+            raise "lol"
+          end
+        rescue
+          redis.get(key).should eq "2"
+        ensure
+          redis.del key
+        end
+      end
+
+      it "can use different Redis DBs" do
+        secondary_uri = redis_uri.dup
+        secondary_uri.path = "/15"
+        secondary_db = Redis::Client.new(uri: secondary_uri)
+        key = random_key
+
+        begin
+          redis.set key, "42"
+          redis.get(key).should eq "42"
+          secondary_db.get(key).should eq nil
+        ensure
+          redis.del key
+          secondary_db.close
+        end
+      end
+
+      describe "streams" do
+        it "can use streams" do
+          key = random_key
+
+          begin
+            # entry_id = redis.xadd key, "*", {"foo" => "bar"}
+            entry_id = redis.xadd key, "*", foo: "bar"
+            range = redis.xrange(key, "-", "+")
+            range.size.should eq 1
+            range.each do |result|
+              id, data = result.as(Array)
+              id.as(String).should eq entry_id
+              data.should eq %w[foo bar]
+            end
+          ensure
+            redis.del key
+          end
+        end
+
+        test "can cap streams" do
+          redis.pipeline do |pipe|
+            11.times { pipe.xadd key, "*", maxlen: "10", foo: "bar" }
+          end
+
+          redis.xlen(key).should eq 10
+        end
+
+        test "can approximately cap streams" do
+          redis.pipeline do |pipe|
+            2_000.times { pipe.xadd key, "*", maxlen: {"~", "10"}, foo: "bar" }
+          end
+
+          redis.xlen(key).should be <= 100
+        end
+
+        it "can consume streams" do
+          key = "my-stream"
+          group = "my-group"
+
+          begin
+            entry_id = redis.xadd key, "*", foo: "bar"
+            # Create a group to consume this stream starting at the beginning
+            redis.xgroup "create", key, group, "0"
+            consumer_id = UUID.random.to_s
+
+            result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
+          rescue ex
+            pp ex
+            raise ex
+          ensure
+            redis.xgroup "destroy", key, group
+            redis.del key
+          end
+        end
+      end
+
+      it "can use transactions" do
+        key = random_key
+
+        begin
+          redis.multi do |redis|
+            redis.set key, "yep"
+            redis.discard
+
+            redis.get "fuck"
+          end.should be_empty
+
+          redis.get(key).should eq nil
+
+          _, nope, _, yep = redis.multi do |redis|
+            redis.set key, "nope"
+            redis.get key
+            redis.set key, "yep"
+            redis.get key
+          end
+
+          nope.should eq "nope"
+          yep.should eq "yep"
+
+          redis.get(key).should eq "yep"
+          redis.del key
+
+          begin
+            redis.multi do |redis|
+              redis.set key, "lol"
+
+              raise "oops"
+            ensure
+              redis.get(key).should eq nil
+            end
+          rescue
+          end
+
+          # Ensure we're still in the same state
+          redis.get(key).should eq nil
+          # Ensure we can still set the key
+          redis.set key, "yep"
+          redis.get(key).should eq "yep"
+        ensure
+          redis.del key
+        end
+      end
+
+      it "works with lists" do
+        key = random_key
+
+        begin
+          spawn do
+            sleep 10.milliseconds
+            redis.lpush key, "omg", "lol", "wtf", "bbq"
+          end
+          redis.brpop(key, timeout: 1).should eq [key, "omg"]
+          redis.brpop(key, timeout: "1").should eq [key, "lol"]
+          redis.brpop(key, timeout: 1.second).should eq [key, "wtf"]
+          redis.brpop(key, timeout: 1.0).should eq [key, "bbq"]
+        ensure
+          redis.del key
+        end
+
+        left = random_key
+        right = random_key
+
+        begin
+          redis.lpush left, "foo"
+          redis.rpoplpush left, right
+          redis.rpop(right).should eq "foo"
+        ensure
+          redis.del left, right
+        end
+      end
+
+      it "can publish and subscribe" do
+        ready = false
+        spawn do
+          until ready
+            Fiber.yield
+          end
+          # Publishes happen on other connections
+          spawn redis.publish "foo", "unsub"
+          spawn redis.publish "bar", "unsub"
+        end
+
+        redis.subscribe "foo", "bar" do |subscription, conn|
+          subscription.on_message do |channel, message|
+            if message == "unsub"
+              conn.unsubscribe channel
+            end
+          end
+
+          subscription.on_subscribe do |channel, count|
+            # Only set ready if *both* subscriptions have gone through
+            ready = true if count == 2
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/instrumentation/jgaskins_redis_spec.cr
+++ b/spec/instrumentation/jgaskins_redis_spec.cr
@@ -1,0 +1,435 @@
+require "uuid"
+require "./jgaskins_redis_spec_helper"
+
+if_defined?(Redis::VERSION) do
+  if_version?(Redis, :>=, "0.3.1") do
+    # Do not use DB slot 15. That's used as the secondary DB for testing the ability
+    # to use DBs other than 0.
+    redis_uri = URI.parse("redis:///")
+    redis = Redis::Client.new(uri: redis_uri)
+
+    private def random_key
+      UUID.random.to_s
+    end
+
+    private macro test(msg, &block)
+      it {{msg}} do
+        key = random_key
+
+        begin
+          {{yield}}
+        ensure
+          redis.del key
+        end
+      end
+    end
+
+    memory = IO::Memory.new
+
+    describe Redis::Client do
+      before_all do
+        OpenTelemetry.configure do |config|
+          config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
+          config.service_version = OpenTelemetry::VERSION
+          config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
+        end
+      end
+
+      after_each do
+        memory.clear
+      end
+
+      it "can set, get, and delete keys" do
+        known_key = random_key
+
+        begin
+          redis.get(random_key).should eq nil
+          redis.set(known_key, "hello")
+          redis.get(known_key).should eq "hello"
+          redis.del(known_key).should eq 1
+          redis.del(known_key).should eq 0
+          redis.get(known_key).should eq nil
+
+          client_traces, server_traces = FindJson.from_io(memory)
+        ensure
+          redis.del known_key
+        end
+      end
+
+      test "can set expiration timestamps on keys" do
+        redis.set key, "foo", ex: 10.milliseconds.from_now
+        redis.get(key).should eq "foo"
+        sleep 10.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key after a specified number of seconds" do
+        redis.set key, "foo"
+        redis.expire key, 1
+        sleep 1.5.seconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key at a given timestamp" do
+        redis.set key, "foo"
+        redis.expireat key, 1.second.from_now
+        sleep 1.second
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key after a specified number of milliseconds" do
+        redis.set key, "foo"
+        redis.pexpire key, 10
+        sleep 100.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can expire key at a given milliseconds-timestamp" do
+        redis.set key, "foo"
+        redis.pexpireat key, 10.milliseconds.from_now
+        sleep 100.milliseconds
+        redis.get(key).should eq nil
+      end
+
+      test "can returns the remaining time to live of a key that has a timeout in seconds" do
+        redis.set key, "foo", ex: 1
+        redis.ttl(key).should eq 1
+      end
+
+      test "can returns the remaining time to live of a key that has a timeout in milliseconds" do
+        redis.set key, "foo", px: 10
+        result = redis.pttl(key)
+        result.should be <= 10
+        result.should be >= 1
+      end
+
+      test "can set a key only if it does not exist" do
+        redis.set(key, "foo", nx: true).should eq "OK"
+        redis.set(key, "foo", nx: true).should eq nil
+      end
+
+      test "can set a key only if it does exist" do
+        redis.set(key, "foo", xx: true).should eq nil
+        redis.set key, "foo"
+        redis.set(key, "foo", xx: true).should eq "OK"
+      end
+
+      it "can get the list of keys" do
+        key = random_key
+
+        begin
+          redis.set key, "yep"
+          redis.keys.includes?(key).should eq true
+        ensure
+          redis.del key
+        end
+      end
+
+      it "can increment and decrement" do
+        key = random_key
+
+        begin
+          redis.incr(key).should eq 1
+          redis.incr(key).should eq 2
+          redis.get(key).should eq "2"
+          redis.decr(key).should eq 1
+          redis.decr(key).should eq 0
+          redis.get(key).should eq "0"
+
+          redis.incrby(key, 2).should eq 2
+          redis.incrby(key, 3).should eq 5
+          redis.decrby(key, 2).should eq 3
+          redis.incrby(key, 1234567812345678).should eq 1234567812345678 + 3
+        ensure
+          redis.del key
+        end
+      end
+
+      describe "sets" do
+        it "can add and remove members of a set" do
+          key = random_key
+
+          begin
+            redis.sadd(key, "a").should eq 1
+            redis.sadd(key, "a").should eq 0
+            redis.smembers(key).should eq %w[a]
+
+            redis.sadd key, "b"
+            redis.smembers(key).includes?("a").should eq true
+            redis.smembers(key).includes?("b").should eq true
+
+            redis.srem key, "a"
+            redis.smembers(key).includes?("a").should eq false
+            redis.smembers(key).includes?("b").should eq true
+          ensure
+            redis.del key
+          end
+        end
+
+        test "can check whether a set has a value" do
+          redis.sismember(key, "a").should eq 0
+          redis.sadd key, "a"
+          redis.sismember(key, "a").should eq 1
+        end
+
+        test "can find the difference in 2 sets" do
+          first = key
+          second = random_key
+
+          redis.sadd first, "a", "b", "c"
+          redis.sadd second, "b", "c", "d"
+
+          # Just the elements of first that are not in second
+          redis.sdiff(first, second).should eq %w[a]
+        ensure
+          redis.del second if second
+        end
+
+        test "can find the intersection of multiple sets" do
+          first = key
+          second = random_key
+          third = random_key
+
+          redis.sadd first, "a", "b", "c"
+          redis.sadd second, "b", "c", "d"
+          redis.sadd third, "c", "d", "e"
+
+          redis.sinter(first, second, third).should eq %w[c]
+        ensure
+          redis.del second, third if second && third
+        end
+
+        test "can determine the number of members of a set" do
+          redis.sadd key, "a"
+          redis.scard(key).should eq 1
+          redis.sadd key, "b", "c"
+          redis.scard(key).should eq 3
+        end
+      end
+
+      it "can pipeline commands" do
+        key = random_key
+
+        begin
+          first_incr = Redis::Future.new
+          second_incr = Redis::Future.new
+          first_decr = Redis::Future.new
+          second_decr = Redis::Future.new
+
+          redis.pipeline do |redis|
+            first_incr = redis.incr key
+            second_incr = redis.incr key
+
+            first_decr = redis.decr key
+            second_decr = redis.decr key
+          end.should eq [1, 2, 1, 0]
+
+          first_incr.value.should eq 1
+          second_incr.value.should eq 2
+          first_decr.value.should eq 1
+          second_decr.value.should eq 0
+        ensure
+          redis.del key
+        end
+      end
+
+      test "checking for existence of keys" do
+        redis.exists(key).should eq 0
+
+        redis.incr key
+        redis.exists(key).should eq 1
+
+        redis.del key
+        redis.exists(key).should eq 0
+      end
+
+      it "handles exceptions while pipelining" do
+        key = random_key
+
+        begin
+          redis.pipeline do |redis|
+            redis.incr key
+            redis.incr key
+            raise "lol"
+          end
+        rescue
+          redis.get(key).should eq "2"
+        ensure
+          redis.del key
+        end
+      end
+
+      it "can use different Redis DBs" do
+        secondary_uri = redis_uri.dup
+        secondary_uri.path = "/15"
+        secondary_db = Redis::Client.new(uri: secondary_uri)
+        key = random_key
+
+        begin
+          redis.set key, "42"
+          redis.get(key).should eq "42"
+          secondary_db.get(key).should eq nil
+        ensure
+          redis.del key
+          secondary_db.close
+        end
+      end
+
+      describe "streams" do
+        it "can use streams" do
+          key = random_key
+
+          begin
+            # entry_id = redis.xadd key, "*", {"foo" => "bar"}
+            entry_id = redis.xadd key, "*", foo: "bar"
+            range = redis.xrange(key, "-", "+")
+            range.size.should eq 1
+            range.each do |result|
+              id, data = result.as(Array)
+              id.as(String).should eq entry_id
+              data.should eq %w[foo bar]
+            end
+          ensure
+            redis.del key
+          end
+        end
+
+        test "can cap streams" do
+          redis.pipeline do |pipe|
+            11.times { pipe.xadd key, "*", maxlen: "10", foo: "bar" }
+          end
+
+          redis.xlen(key).should eq 10
+        end
+
+        test "can approximately cap streams" do
+          redis.pipeline do |pipe|
+            2_000.times { pipe.xadd key, "*", maxlen: {"~", "10"}, foo: "bar" }
+          end
+
+          redis.xlen(key).should be <= 100
+        end
+
+        it "can consume streams" do
+          key = "my-stream"
+          group = "my-group"
+
+          begin
+            entry_id = redis.xadd key, "*", foo: "bar"
+            # Create a group to consume this stream starting at the beginning
+            redis.xgroup "create", key, group, "0"
+            consumer_id = UUID.random.to_s
+
+            result = redis.xreadgroup group, consumer_id, count: "10", streams: {"my-stream": ">"}
+          rescue ex
+            pp ex
+            raise ex
+          ensure
+            redis.xgroup "destroy", key, group
+            redis.del key
+          end
+        end
+      end
+
+      it "can use transactions" do
+        key = random_key
+
+        begin
+          redis.multi do |redis|
+            redis.set key, "yep"
+            redis.discard
+
+            redis.get "fuck"
+          end.should be_empty
+
+          redis.get(key).should eq nil
+
+          _, nope, _, yep = redis.multi do |redis|
+            redis.set key, "nope"
+            redis.get key
+            redis.set key, "yep"
+            redis.get key
+          end
+
+          nope.should eq "nope"
+          yep.should eq "yep"
+
+          redis.get(key).should eq "yep"
+          redis.del key
+
+          begin
+            redis.multi do |redis|
+              redis.set key, "lol"
+
+              raise "oops"
+            ensure
+              redis.get(key).should eq nil
+            end
+          rescue
+          end
+
+          # Ensure we're still in the same state
+          redis.get(key).should eq nil
+          # Ensure we can still set the key
+          redis.set key, "yep"
+          redis.get(key).should eq "yep"
+        ensure
+          redis.del key
+        end
+      end
+
+      it "works with lists" do
+        key = random_key
+
+        begin
+          spawn do
+            sleep 10.milliseconds
+            redis.lpush key, "omg", "lol", "wtf", "bbq"
+          end
+          redis.brpop(key, timeout: 1).should eq [key, "omg"]
+          redis.brpop(key, timeout: "1").should eq [key, "lol"]
+          redis.brpop(key, timeout: 1.second).should eq [key, "wtf"]
+          redis.brpop(key, timeout: 1.0).should eq [key, "bbq"]
+        ensure
+          redis.del key
+        end
+
+        left = random_key
+        right = random_key
+
+        begin
+          redis.lpush left, "foo"
+          redis.rpoplpush left, right
+          redis.rpop(right).should eq "foo"
+        ensure
+          redis.del left, right
+        end
+      end
+
+      it "can publish and subscribe" do
+        ready = false
+        spawn do
+          until ready
+            Fiber.yield
+          end
+          # Publishes happen on other connections
+          spawn redis.publish "foo", "unsub"
+          spawn redis.publish "bar", "unsub"
+        end
+
+        redis.subscribe "foo", "bar" do |subscription, conn|
+          subscription.on_message do |channel, message|
+            if message == "unsub"
+              conn.unsubscribe channel
+            end
+          end
+
+          subscription.on_subscribe do |channel, count|
+            # Only set ready if *both* subscriptions have gone through
+            ready = true if count == 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/instrumentation/jgaskins_redis_spec_helper.cr
+++ b/spec/instrumentation/jgaskins_redis_spec_helper.cr
@@ -1,0 +1,2 @@
+require "spec"
+require "redis"

--- a/spec/instrumentation/stefanwille_redis_spec.cr
+++ b/spec/instrumentation/stefanwille_redis_spec.cr
@@ -1,4 +1,5 @@
 require "./stefanwille_redis_spec_helper"
+require "../../src/opentelemetry/instrumentation/db/stefanwille_redis"
 
 describe Redis do
   Spec.before_suite do

--- a/spec/instrumentation/stefanwille_redis_spec.cr
+++ b/spec/instrumentation/stefanwille_redis_spec.cr
@@ -1,2465 +1,2468 @@
 require "./stefanwille_redis_spec_helper"
 require "../../src/opentelemetry/instrumentation/db/stefanwille_redis"
 
-begin
-  Redis.new
-  redis_is_running = true
-rescue
-  redis_is_running = false
-end
-
-memory = IO::Memory.new
-
-describe Redis do
-  before_all do
-    OpenTelemetry.configure do |config|
-      config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
-      config.service_version = OpenTelemetry::VERSION
-      config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
-    end
+if_defined?(Redis::Strategy::SingleStatement) do
+  begin
+    Redis.new
+    redis_is_running = true
+  rescue
+    redis_is_running = false
   end
 
-  after_each do
-    memory.clear
-  end
+  memory = IO::Memory.new
 
-  describe ".new" do
-    if redis_is_running
-      it "connects to default host and port" do
-        Redis.new
+  describe Redis do
+    before_all do
+      OpenTelemetry.configure do |config|
+        pp "BANGIN IO BACKEND NOW"
+        config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
+        config.service_version = OpenTelemetry::VERSION
+        config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
       end
-    else
-      pending ":redis is not running: connects to default host and port"
     end
 
-    if redis_is_running
-      it "connects to specific port and host / disconnects" do
-        Redis.new(host: "localhost", port: 6379)
-      end
-    else
-      pending ":redis is not running: connects to specific port and host"
+    after_each do
+      memory.clear
     end
 
-    if redis_is_running
-      it "connects to a specific database" do
-        redis = Redis.new(host: "localhost", port: 6379, database: 1)
-        redis.not_nil!.url.should eq("redis://localhost:6379/1")
-      end
-    else
-      pending ":redis is not running: connects to a specific database"
-    end
-
-    # if redis_is_running
-    #   it "connects to Unix domain sockets" do
-    #     redis = Redis.new(unixsocket: TEST_UNIXSOCKET)
-    #     redis.not_nil!.url.should eq("redis://#{TEST_UNIXSOCKET}/0")
-    #     redis.not_nil!.ping.should eq "PONG"
-    #   end
-    # else
-    #   pending ":redis is not running: connects to Unix domain sockets"
-    # end
-
-    context "when url argument is given" do
+    describe ".new" do
       if redis_is_running
-        it "connects using given URL" do
-          redis = Redis.new(url: "redis://127.0.0.1", host: "host.to.be.ignored", port: 1234)
-          redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
+        it "connects to default host and port" do
+          Redis.new
         end
       else
-        pending ":redis is not running: connects using given URL"
-      end
-    end
-
-    context "when url argument with trailing slash is given" do
-      if redis_is_running
-        it "connects using given URL" do
-          redis = Redis.new(url: "redis://127.0.0.1/")
-          redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
-        end
-      else
-        pending ":redis is not running: connects using given URL"
-      end
-    end
-
-    it "raises ConnectionError when it cant connect to redis" do
-      expect_raises(Redis::CannotConnectError, "Socket::ConnectError: Error connecting to 'localhost:12345': Connection refused") do
-        Redis.new(host: "localhost", port: 12345)
-      end
-    end
-
-    describe "#close" do
-      if redis_is_running
-        it "closes the connection" do
-          redis = Redis.new
-          redis.not_nil!.close
-        end
-      else
-        pending ":redis is not running: closes the connection"
+        pending ":redis is not running: connects to default host and port"
       end
 
       if redis_is_running
-        it "tolerates a duplicate call" do
-          redis = Redis.new
-          redis.not_nil!.close
-          redis.not_nil!.close
+        it "connects to specific port and host / disconnects" do
+          Redis.new(host: "localhost", port: 6379)
         end
       else
-        pending ":redis is not running: tolerates a duplicate call"
+        pending ":redis is not running: connects to specific port and host"
       end
-    end
-  end
 
-  describe ".open" do
-    if redis_is_running
-      it "connects to the Redis server using the given connection params, yields its block and disconnects" do
-        Redis.open(host: "localhost", port: 6379) do |redis|
-          redis.not_nil!.ping
+      if redis_is_running
+        it "connects to a specific database" do
+          redis = Redis.new(host: "localhost", port: 6379, database: 1)
+          redis.not_nil!.url.should eq("redis://localhost:6379/1")
+        end
+      else
+        pending ":redis is not running: connects to a specific database"
+      end
+
+      # if redis_is_running
+      #   it "connects to Unix domain sockets" do
+      #     redis = Redis.new(unixsocket: TEST_UNIXSOCKET)
+      #     redis.not_nil!.url.should eq("redis://#{TEST_UNIXSOCKET}/0")
+      #     redis.not_nil!.ping.should eq "PONG"
+      #   end
+      # else
+      #   pending ":redis is not running: connects to Unix domain sockets"
+      # end
+
+      context "when url argument is given" do
+        if redis_is_running
+          it "connects using given URL" do
+            redis = Redis.new(url: "redis://127.0.0.1", host: "host.to.be.ignored", port: 1234)
+            redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
+          end
+        else
+          pending ":redis is not running: connects using given URL"
         end
       end
-    else
-      pending ":redis is not running: connects to the Redis server using the given connection params, yields its block and disconnects"
-    end
 
-    if redis_is_running
-      it "connects to the Redis using the given url, yields its block and disconnects" do
-        Redis.open(url: "redis://127.0.0.1") do |redis|
-          redis.not_nil!.ping
+      context "when url argument with trailing slash is given" do
+        if redis_is_running
+          it "connects using given URL" do
+            redis = Redis.new(url: "redis://127.0.0.1/")
+            redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
+          end
+        else
+          pending ":redis is not running: connects using given URL"
         end
       end
-    else
-      pending ":redis is not running: connects to the Redis using the given url, yields its block and disconnects"
-    end
-  end
 
-  describe "#url" do
+      it "raises ConnectionError when it cant connect to redis" do
+        expect_raises(Redis::CannotConnectError, "Socket::ConnectError: Error connecting to 'localhost:12345': Connection refused") do
+          Redis.new(host: "localhost", port: 12345)
+        end
+      end
+
+      describe "#close" do
+        if redis_is_running
+          it "closes the connection" do
+            redis = Redis.new
+            redis.not_nil!.close
+          end
+        else
+          pending ":redis is not running: closes the connection"
+        end
+
+        if redis_is_running
+          it "tolerates a duplicate call" do
+            redis = Redis.new
+            redis.not_nil!.close
+            redis.not_nil!.close
+          end
+        else
+          pending ":redis is not running: tolerates a duplicate call"
+        end
+      end
+    end
+
+    describe ".open" do
+      if redis_is_running
+        it "connects to the Redis server using the given connection params, yields its block and disconnects" do
+          Redis.open(host: "localhost", port: 6379) do |redis|
+            redis.not_nil!.ping
+          end
+        end
+      else
+        pending ":redis is not running: connects to the Redis server using the given connection params, yields its block and disconnects"
+      end
+
+      if redis_is_running
+        it "connects to the Redis using the given url, yields its block and disconnects" do
+          Redis.open(url: "redis://127.0.0.1") do |redis|
+            redis.not_nil!.ping
+          end
+        end
+      else
+        pending ":redis is not running: connects to the Redis using the given url, yields its block and disconnects"
+      end
+    end
+
+    describe "#url" do
+      if redis_is_running
+        it "returns the server url" do
+          Redis.open do |redis|
+            redis.not_nil!.url.should eq("redis://localhost:6379/0")
+          end
+          Redis.open(url: "redis://127.0.0.1") do |redis|
+            redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
+          end
+        end
+      else
+        pending ":redis is not running: returns the server url"
+      end
+    end
+
     if redis_is_running
-      it "returns the server url" do
+      it "#ping" do
         Redis.open do |redis|
-          redis.not_nil!.url.should eq("redis://localhost:6379/0")
-        end
-        Redis.open(url: "redis://127.0.0.1") do |redis|
-          redis.not_nil!.url.should eq("redis://127.0.0.1:6379/0")
+          redis.not_nil!.ping.should eq("PONG")
         end
       end
     else
-      pending ":redis is not running: returns the server url"
+      pending ":redis is not running: #ping"
     end
-  end
 
-  if redis_is_running
-    it "#ping" do
-      Redis.open do |redis|
-        redis.not_nil!.ping.should eq("PONG")
+    if redis_is_running
+      it "#echo" do
+        Redis.open do |redis|
+          redis.not_nil!.echo("Ciao").should eq("Ciao")
+        end
       end
+    else
+      pending ":redis is not running: #echo"
     end
-  else
-    pending ":redis is not running: #ping"
-  end
 
-  if redis_is_running
-    it "#echo" do
-      Redis.open do |redis|
-        redis.not_nil!.echo("Ciao").should eq("Ciao")
+    if redis_is_running
+      it "#quit" do
+        Redis.open do |redis|
+          redis.not_nil!.quit.should eq("OK")
+        end
       end
+    else
+      pending ":redis is not running: #quit"
     end
-  else
-    pending ":redis is not running: #echo"
-  end
 
-  if redis_is_running
-    it "#quit" do
-      Redis.open do |redis|
-        redis.not_nil!.quit.should eq("OK")
+    if redis_is_running
+      it "#flushdb" do
+        Redis.open do |redis|
+          redis.not_nil!.set("foo", "test")
+          redis.not_nil!.get("foo").should eq("test")
+
+          redis.not_nil!.flushdb.should eq("OK")
+
+          redis.not_nil!.get("foo").should eq(nil)
+        end
       end
+    else
+      pending ":redis is not running: #flushdb"
     end
-  else
-    pending ":redis is not running: #quit"
-  end
 
-  if redis_is_running
-    it "#flushdb" do
-      Redis.open do |redis|
-        redis.not_nil!.set("foo", "test")
-        redis.not_nil!.get("foo").should eq("test")
-
-        redis.not_nil!.flushdb.should eq("OK")
-
-        redis.not_nil!.get("foo").should eq(nil)
+    if redis_is_running
+      it "#select" do
+        Redis.open do |redis|
+          redis.not_nil!.select(0).should eq("OK")
+        end
       end
+    else
+      pending ":redis is not running: #select"
     end
-  else
-    pending ":redis is not running: #flushdb"
-  end
 
-  if redis_is_running
-    it "#select" do
-      Redis.open do |redis|
-        redis.not_nil!.select(0).should eq("OK")
+    if redis_is_running
+      it "#auth" do
+        Redis.open do |redis|
+          expect_raises(Redis::Error, "ERR AUTH <password> called without any password configured for the default user") do
+            redis.not_nil!.auth("some-password").should eq("OK")
+          end
+        end
       end
+    else
+      pending ":redis is not running: #auth"
     end
-  else
-    pending ":redis is not running: #select"
-  end
 
-  if redis_is_running
-    it "#auth" do
-      Redis.open do |redis|
-        expect_raises(Redis::Error, "ERR AUTH <password> called without any password configured for the default user") do
-          redis.not_nil!.auth("some-password").should eq("OK")
-        end
-      end
-    end
-  else
-    pending ":redis is not running: #auth"
-  end
-
-  {nil, "my_namespace"}.each do |namespace|
-    context "(namespace: #{namespace})" do
-      describe "keys" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#del" do
-            redis.not_nil!.set("foo", "test")
-            redis.not_nil!.del("foo")
-            redis.not_nil!.get("foo").should eq(nil)
-
-            redis.not_nil!.mset({"foo1" => "bar1", "foo2" => "bar2"})
-            redis.not_nil!.del(["foo1", "foo2"]).should eq(2)
-          end
-        else
-          pending ":redis is not running: #del"
-        end
-
-        if redis_is_running
-          it "converts keys to strings" do
-            redis.not_nil!.set(:foo, "hello")
-            redis.not_nil!.set(123456, 7)
-            redis.not_nil!.get("foo").should eq("hello")
-            redis.not_nil!.get("123456").should eq("7")
-          end
-        else
-          pending ":redis is not running: converts keys to strings"
-        end
-
-        if redis_is_running
-          it "#rename" do
-            redis.not_nil!.del("foo", "bar")
-            redis.not_nil!.set("foo", "test")
-            redis.not_nil!.rename("foo", "bar")
-            redis.not_nil!.get("bar").should eq("test")
-          end
-        else
-          pending ":redis is not running: #rename"
-        end
-
-        if redis_is_running
-          it "#renamenx" do
-            redis.not_nil!.set("foo", "Hello")
-            redis.not_nil!.set("bar", "world")
-            redis.not_nil!.renamenx("foo", "bar").should eq(0)
-            redis.not_nil!.get("bar").should eq("world")
-
-            client_traces, _server_traces = FindJson.from_io(memory)
-            # Spot Check some traces here...
-            client_traces.size.should eq 4
-            client_traces[0]["spans"][0]["name"].should eq "Redis: GET #{[namespace, "bar"].compact!.join("::")}"
-            client_traces[0]["spans"][0]["attributes"]["db.system"].should eq "redis"
-            client_traces[0]["spans"][0]["attributes"]["db.statement"].should eq "GET #{[namespace, "bar"].compact!.join("::")}"
-            client_traces[0]["spans"][0]["attributes"]["net.transport"].should eq "ip_tcp"
-          end
-        else
-          pending ":redis is not running: #renamenx"
-        end
-
-        if redis_is_running
-          it "#randomkey" do
-            redis.not_nil!.set("foo", "Hello")
-            redis.not_nil!.randomkey.should_not be_nil
-          end
-        else
-          pending ":redis is not running: #randomkey"
-        end
-
-        if redis_is_running
-          it "#exists" do
-            redis.not_nil!.del("foo")
-            redis.not_nil!.exists("foo").should eq(0)
-            redis.not_nil!.set("foo", "test")
-            redis.not_nil!.exists("foo").should eq(1)
-          end
-        else
-          pending ":redis is not running: #exists"
-        end
-
-        if redis_is_running
-          it "#keys" do
-            redis.not_nil!.set("callmemaybe", 1)
-            redis.not_nil!.keys("callmemaybe").should eq(["callmemaybe"])
-          end
-        else
-          pending ":redis is not running: #keys"
-        end
-
-        describe "#sort" do
-          if redis_is_running
-            it "sorts the container" do
-              redis.not_nil!.del("mylist")
-              redis.not_nil!.rpush("mylist", "1", "3", "2")
-              redis.not_nil!.sort("mylist").should eq(["1", "2", "3"])
-              redis.not_nil!.sort("mylist", order: "DESC").should eq(["3", "2", "1"])
-            end
-          else
-            pending ":redis is not running: sorts the container"
-          end
-
-          if redis_is_running
-            it "limit" do
-              redis.not_nil!.del("mylist")
-              redis.not_nil!.rpush("mylist", "1", "3", "2")
-              redis.not_nil!.sort("mylist", limit: [1, 2]).should eq(["2", "3"])
-            end
-          else
-            pending ":redis is not running: limit"
-          end
-
-          if redis_is_running
-            it "by" do
-              redis.not_nil!.del("mylist", "objects", "weights")
-              redis.not_nil!.rpush("mylist", "1", "3", "2")
-              redis.not_nil!.mset({"weight_1" => 1, "weight_2" => 2, "weight_3" => 3})
-              redis.not_nil!.sort("mylist", by: "weights_*").should eq(["1", "2", "3"])
-            end
-          else
-            pending ":redis is not running: by"
-          end
-
-          if redis_is_running
-            it "alpha" do
-              redis.not_nil!.del("mylist")
-              redis.not_nil!.rpush("mylist", "c", "a", "b")
-              redis.not_nil!.sort("mylist", alpha: true).should eq(["a", "b", "c"])
-            end
-          else
-            pending ":redis is not running: alpha"
-          end
-
-          if redis_is_running
-            it "store" do
-              redis.not_nil!.del("mylist", "destination")
-              redis.not_nil!.rpush("mylist", "1", "3", "2")
-              redis.not_nil!.sort("mylist", store: "destination")
-              redis.not_nil!.lrange("destination", 0, 2).should eq(["1", "2", "3"])
-            end
-          else
-            pending ":redis is not running: store"
-          end
-        end
-
-        if redis_is_running
-          it "#dump / #restore" do
-            Redis.open do |inner_redis|
-              inner_redis.not_nil!.set("foo", "9")
-              serialized_value = inner_redis.not_nil!.dump("foo")
-              inner_redis.not_nil!.del("foo")
-              inner_redis.not_nil!.restore("foo", 0, serialized_value).should eq("OK")
-              inner_redis.not_nil!.get("foo").should eq("9")
-              inner_redis.not_nil!.ttl("foo").should eq(-1)
-            end
-          end
-        else
-          pending ":redis is not running: #dump / #restore"
-        end
-      end
-
-      describe "select database" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "select database when connect" do
-            redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
-            redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
-
-            redis1.del("test_database")
-            redis2.del("test_database")
-
-            redis1.set("test_database", "1")
-            redis2.set("test_database", "2")
-
-            redis1.get("test_database").should eq "1"
-            redis2.get("test_database").should eq "2"
-          end
-        else
-          pending ":redis is not running: select database when connect"
-        end
-
-        if redis_is_running
-          it "select database by command" do
-            redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
-            redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
-
-            redis1.del("test_database")
-            redis2.del("test_database")
-
-            redis1.set("test_database", "1")
-            redis2.set("test_database", "2")
-
-            redis.not_nil!.select(1)
-            redis.not_nil!.get("test_database").should eq "1"
-
-            redis.not_nil!.select(2)
-            redis.not_nil!.get("test_database").should eq "2"
-          end
-        else
-          pending ":redis is not running: select database by command"
-        end
-
-        if redis_is_running
-          it "does nothing if current database is the same as given one" do
-            redis.not_nil!.select(2).should eq "OK"
-            redis.not_nil!.select(1).should eq "OK"
-            redis.not_nil!.select(1).should eq "OK"
-            # There is no good way to assert that no command was sent
-          end
-        else
-          pending ":redis is not running: does nothing if current database is the same as given one"
-        end
-      end
-
-      describe "strings" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#set / #get" do
-            redis.not_nil!.set("foo", "test")
-            redis.not_nil!.get("foo").should eq("test")
-          end
-        else
-          pending ":redis is not running: #set / #get"
-        end
-
-        if redis_is_running
-          it "#set options" do
-            redis.not_nil!.set("foo", "test", ex: 7)
-            redis.not_nil!.ttl("foo").should eq(7)
-
-            redis.not_nil!.set("foo", "test", px: 7)
-            redis.not_nil!.ttl("foo").should eq(0)
-
-            redis.not_nil!.set("foo", "test", nx: true)
-
-            redis.not_nil!.set("foo", "test", xx: true)
-          end
-        else
-          pending ":redis is not running: #set options"
-        end
-
-        if redis_is_running
-          it "#mget" do
-            redis.not_nil!.set("foo1", "test1")
-            redis.not_nil!.set("foo2", "test2")
-            redis.not_nil!.mget("foo1", "foo2").should eq(["test1", "test2"])
-            redis.not_nil!.mget(["foo2", "foo1"]).should eq(["test2", "test1"])
-          end
-        else
-          pending ":redis is not running: #mget"
-        end
-
-        if redis_is_running
-          it "#mset" do
-            redis.not_nil!.mset({"foo1" => "bar1", "foo2" => "bar2"})
-            redis.not_nil!.get("foo1").should eq("bar1")
-            redis.not_nil!.get("foo2").should eq("bar2")
-          end
-        else
-          pending ":redis is not running: #mset"
-        end
-
-        if redis_is_running
-          it "#getset" do
-            redis.not_nil!.set("foo", "old")
-            redis.not_nil!.getset("foo", "new").should eq("old")
-            redis.not_nil!.get("foo").should eq("new")
-          end
-        else
-          pending ":redis is not running: #getset"
-        end
-
-        if redis_is_running
-          it "#setex" do
-            redis.not_nil!.setex("foo", 3, "setexed")
-            redis.not_nil!.get("foo").should eq("setexed")
-          end
-        else
-          pending ":redis is not running: #setex"
-        end
-
-        if redis_is_running
-          it "#psetex" do
-            redis.not_nil!.psetex("foo", 3000, "psetexed")
-            redis.not_nil!.get("foo").should eq("psetexed")
-          end
-        else
-          pending ":redis is not running: #psetex"
-        end
-
-        if redis_is_running
-          it "#setnx" do
-            redis.not_nil!.del("foo")
-            redis.not_nil!.setnx("foo", "setnxed").should eq(1)
-            redis.not_nil!.get("foo").should eq("setnxed")
-            redis.not_nil!.setnx("foo", "setnxed2").should eq(0)
-            redis.not_nil!.get("foo").should eq("setnxed")
-          end
-        else
-          pending ":redis is not running: #setnx"
-        end
-
-        if redis_is_running
-          it "#msetnx" do
-            redis.not_nil!.del("key1", "key2", "key3")
-            redis.not_nil!.msetnx({"key1": "hello", "key2": "there"}).should eq(1)
-            redis.not_nil!.get("key1").should eq("hello")
-            redis.not_nil!.get("key2").should eq("there")
-            redis.not_nil!.msetnx({"key2": "keep", "key3": "singing"}).should eq(0)
-            redis.not_nil!.get("key1").should eq("hello")
-            redis.not_nil!.get("key2").should eq("there")
-            redis.not_nil!.get("key3").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #msetnx"
-        end
-
-        if redis_is_running
-          it "#incr" do
-            redis.not_nil!.set("foo", "3")
-            redis.not_nil!.incr("foo").should eq(4)
-          end
-        else
-          pending ":redis is not running: #incr"
-        end
-
-        if redis_is_running
-          it "#decr" do
-            redis.not_nil!.set("foo", "3")
-            redis.not_nil!.decr("foo").should eq(2)
-          end
-        else
-          pending ":redis is not running: #decr"
-        end
-
-        if redis_is_running
-          it "#incrby" do
-            redis.not_nil!.set("foo", "10")
-            redis.not_nil!.incrby("foo", 4).should eq(14)
-          end
-        else
-          pending ":redis is not running: #incrby"
-        end
-
-        if redis_is_running
-          it "#decrby" do
-            redis.not_nil!.set("foo", "10")
-            redis.not_nil!.decrby("foo", 4).should eq(6)
-          end
-        else
-          pending ":redis is not running: #decrby"
-        end
-
-        if redis_is_running
-          it "#incrbyfloat" do
-            redis.not_nil!.set("foo", "10")
-            redis.not_nil!.incrbyfloat("foo", 2.5).should eq("12.5")
-          end
-        else
-          pending ":redis is not running: #incrbyfloat"
-        end
-
-        if redis_is_running
-          it "#append" do
-            redis.not_nil!.set("foo", "hello")
-            redis.not_nil!.append("foo", " world")
-            redis.not_nil!.get("foo").should eq("hello world")
-          end
-        else
-          pending ":redis is not running: #append"
-        end
-
-        if redis_is_running
-          it "#strlen" do
-            redis.not_nil!.set("foo", "Hello world")
-            redis.not_nil!.strlen("foo").should eq(11)
-            redis.not_nil!.del("foo")
-            redis.not_nil!.strlen("foo").should eq(0)
-          end
-        else
-          pending ":redis is not running: #strlen"
-        end
-
-        if redis_is_running
-          it "#getrange" do
-            redis.not_nil!.set("foo", "This is a string")
-            redis.not_nil!.getrange("foo", 0, 3).should eq("This")
-            redis.not_nil!.getrange("foo", -3, -1).should eq("ing")
-          end
-        else
-          pending ":redis is not running: #getrange"
-        end
-
-        if redis_is_running
-          it "#setrange" do
-            redis.not_nil!.set("foo", "Hello world")
-            redis.not_nil!.setrange("foo", 6, "Redis").should eq(11)
-            redis.not_nil!.get("foo").should eq("Hello Redis")
-          end
-        else
-          pending ":redis is not running: #setrange"
-        end
-
-        describe "#scan" do
-          if redis_is_running
-            it "no options" do
-              redis.not_nil!.set("foo", "Hello world")
-              new_cursor, keys = redis.not_nil!.scan(0)
-              new_cursor = new_cursor.as(String)
-              new_cursor.to_i.should be > 0
-              keys.is_a?(Array).should be_true
-            end
-          else
-            pending ":redis is not running: no options"
-          end
-
-          if redis_is_running
-            it "with match" do
-              redis.not_nil!.set("scan.match1", "1")
-              redis.not_nil!.set("scan.match2", "2")
-              new_cursor, keys = redis.not_nil!.scan(0, "scan.match*")
-              new_cursor = new_cursor.as(String)
-              new_cursor.to_i.should be > 0
-              keys.is_a?(Array).should be_true
-              # Here `keys.size` should be 0 or 1 or 2, but I don't know how to test it.
-            end
-          else
-            pending ":redis is not running: with match"
-          end
-
-          if redis_is_running
-            it "with match and count" do
-              redis.not_nil!.set("scan.match1", "1")
-              redis.not_nil!.set("scan.match2", "2")
-              new_cursor, keys = redis.not_nil!.scan(0, "scan.match*", 1)
-              new_cursor = new_cursor.as(String)
-              new_cursor.to_i.should be > 0
-              keys.is_a?(Array).should be_true
-              # Here `keys.size` should be 0 or 1, but I don't know how to test it.
-            end
-          else
-            pending ":redis is not running: with match and count"
-          end
-
-          if redis_is_running
-            it "with match and count at once" do
-              redis.not_nil!.set("scan.match1", "1")
-              redis.not_nil!.set("scan.match2", "2")
-              # assumes that current Redis instance has at most 10M entries
-              new_cursor, keys = redis.not_nil!.scan(0, "scan.match*", 10_000_000)
-              new_cursor.should eq("0")
-              array(keys).sort.should eq(["scan.match1", "scan.match2"])
-            end
-          else
-            pending ":redis is not running: with match and count at once"
-          end
-        end
-      end
-
-      describe "bit operations" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#bitcount" do
-            redis.not_nil!.set("foo", "foobar")
-            redis.not_nil!.bitcount("foo", 0, 0).should eq(4)
-            redis.not_nil!.bitcount("foo", 1, 1).should eq(6)
-          end
-        else
-          pending ":redis is not running: #bitcount"
-        end
-
-        if redis_is_running
-          it "#bitop" do
-            redis.not_nil!.set("key1", "foobar")
-            redis.not_nil!.set("key2", "abcdef")
-            redis.not_nil!.bitop("and", "dest", "key1", "key2").should eq(6)
-            redis.not_nil!.get("dest").should eq("`bc`ab")
-          end
-        else
-          pending ":redis is not running: #bitop"
-        end
-
-        if redis_is_running
-          it "#bitpos" do
-            redis.not_nil!.set("mykey", "0")
-            redis.not_nil!.bitpos("mykey", 1).should eq(2)
-          end
-        else
-          pending ":redis is not running: #bitpos"
-        end
-
-        if redis_is_running
-          it "#getbit / #setbit" do
-            redis.not_nil!.del("mykey")
-            redis.not_nil!.setbit("mykey", 7, 1).should eq(0)
-            redis.not_nil!.getbit("mykey", 0).should eq(0)
-            redis.not_nil!.getbit("mykey", 7).should eq(1)
-            redis.not_nil!.getbit("mykey", 100).should eq(0)
-          end
-        else
-          pending ":redis is not running: #getbit / #setbit"
-        end
-      end
-
-      describe "lists" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#rpush / #lrange" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello").should eq(1)
-            redis.not_nil!.rpush("mylist", "world").should eq(2)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
-            redis.not_nil!.rpush("mylist", "snip", "snip").should eq(4)
-          end
-        else
-          pending ":redis is not running: #rpush / #lrange"
-        end
-
-        if redis_is_running
-          it "#lpush" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.lpush("mylist", "hello").should eq(1)
-            redis.not_nil!.lpush("mylist", ["world"]).should eq(2)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["world", "hello"])
-            redis.not_nil!.lpush("mylist", "snip", "snip").should eq(4)
-          end
-        else
-          pending ":redis is not running: #lpush"
-        end
-
-        if redis_is_running
-          it "#lpushx" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.lpushx("mylist", "hello").should eq(0)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
-            redis.not_nil!.lpush("mylist", "hello")
-            redis.not_nil!.lpushx("mylist", "world").should eq(2)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["world", "hello"])
-          end
-        else
-          pending ":redis is not running: #lpushx"
-        end
-
-        if redis_is_running
-          it "#rpushx" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpushx("mylist", "hello").should eq(0)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpushx("mylist", "world").should eq(2)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
-          end
-        else
-          pending ":redis is not running: #rpushx"
-        end
-
-        if redis_is_running
-          it "#lrem" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "my")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.lrem("mylist", 1, "my").should eq(1)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
-            redis.not_nil!.lrem("mylist", 0, "world").should eq(1)
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello"])
-          end
-        else
-          pending ":redis is not running: #lrem"
-        end
-
-        if redis_is_running
-          it "#llen" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.lpush("mylist", "hello")
-            redis.not_nil!.lpush("mylist", "world")
-            redis.not_nil!.llen("mylist").should eq(2)
-          end
-        else
-          pending ":redis is not running: #llen"
-        end
-
-        if redis_is_running
-          it "#lset" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.lset("mylist", 0, "goodbye").should eq("OK")
-            redis.not_nil!.lrange("mylist", 0, 1).should eq(["goodbye", "world"])
-          end
-        else
-          pending ":redis is not running: #lset"
-        end
-
-        if redis_is_running
-          it "#lindex" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.lindex("mylist", 0).should eq("hello")
-            redis.not_nil!.lindex("mylist", 1).should eq("world")
-            redis.not_nil!.lindex("mylist", 2).should eq(nil)
-          end
-        else
-          pending ":redis is not running: #lindex"
-        end
-
-        if redis_is_running
-          it "#lpop" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.lpop("mylist").should eq("hello")
-            redis.not_nil!.lpop("mylist").should eq("world")
-            redis.not_nil!.lpop("mylist").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #lpop"
-        end
-
-        if redis_is_running
-          it "#rpop" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.rpop("mylist").should eq("world")
-            redis.not_nil!.rpop("mylist").should eq("hello")
-            redis.not_nil!.rpop("mylist").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #rpop"
-        end
-
-        if redis_is_running
-          it "#linsert" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello")
-            redis.not_nil!.rpush("mylist", "world")
-            redis.not_nil!.linsert("mylist", :before, "world", "dear").should eq(3)
-            redis.not_nil!.lrange("mylist", 0, 2).should eq(["hello", "dear", "world"])
-          end
-        else
-          pending ":redis is not running: #linsert"
-        end
-
-        if redis_is_running
-          it "#blpop" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.del("myotherlist")
-            redis.not_nil!.rpush("mylist", "hello", "world")
-            redis.not_nil!.blpop(["myotherlist", "mylist"], 1).should eq(["mylist", "hello"])
-          end
-        else
-          pending ":redis is not running: #blpop"
-        end
-
-        if redis_is_running
-          it "#blpop with no data, should not raise" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.del("myotherlist")
-            redis.not_nil!.blpop(["myotherlist", "mylist"], 1).should eq([] of String)
-          end
-        else
-          pending ":redis is not running: #blpop"
-        end
-
-        if redis_is_running
-          it "#ltrim" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "hello", "good", "world")
-            redis.not_nil!.ltrim("mylist", 0, 0).should eq("OK")
-            redis.not_nil!.lrange("mylist", 0, 2).should eq(["hello"])
-          end
-        else
-          pending ":redis is not running: #ltrim"
-        end
-
-        if redis_is_running
-          it "#brpop" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.del("myotherlist")
-            redis.not_nil!.rpush("mylist", "hello", "world")
-            redis.not_nil!.brpop(["myotherlist", "mylist"], 1).should eq(["mylist", "world"])
-
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.brpop(["mylist"], 1).should eq([] of String)
-          end
-        else
-          pending ":redis is not running: #brpop"
-        end
-
-        if redis_is_running
-          it "#brpop with no data, should not raise" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.del("myotherlist")
-            redis.not_nil!.brpop(["myotherlist", "mylist"], 1).should eq([] of String)
-          end
-        else
-          pending ":redis is not running: #brpop"
-        end
-
-        if redis_is_running
-          it "#rpoplpush" do
-            redis.not_nil!.del("source")
-            redis.not_nil!.del("destination")
-            redis.not_nil!.rpush("source", "a", "b", "c")
-            redis.not_nil!.rpush("destination", "1", "2", "3")
-            redis.not_nil!.rpoplpush("source", "destination")
-            redis.not_nil!.lrange("source", 0, 4).should eq(["a", "b"])
-            redis.not_nil!.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
-          end
-        else
-          pending ":redis is not running: #rpoplpush"
-        end
-
-        if redis_is_running
-          it "#brpoplpush" do
-            redis.not_nil!.del("source")
-            redis.not_nil!.del("destination")
-            redis.not_nil!.rpush("source", "a", "b", "c")
-            redis.not_nil!.rpush("destination", "1", "2", "3")
-            redis.not_nil!.brpoplpush("source", "destination", 0)
-            redis.not_nil!.lrange("source", 0, 4).should eq(["a", "b"])
-            redis.not_nil!.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
-
-            # timeout test (#68)
-            redis.not_nil!.del("source")
-            redis.not_nil!.brpoplpush("source", "destination", 1).should eq(nil)
-          end
-        else
-          pending ":redis is not running: #brpoplpush"
-        end
-      end
-
-      describe "sets" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#sadd / #smembers" do
-            redis.not_nil!.del("myset")
-            redis.not_nil!.sadd("myset", "Hello").should eq(1)
-            redis.not_nil!.sadd("myset", "World").should eq(1)
-            redis.not_nil!.sadd("myset", "World").should eq(0)
-            redis.not_nil!.sadd("myset", ["Foo", "Bar"]).should eq(2)
-            sort(redis.not_nil!.smembers("myset")).should eq(["Bar", "Foo", "Hello", "World"])
-          end
-        else
-          pending ":redis is not running: #sadd / #smembers"
-        end
-
-        if redis_is_running
-          it "#scard" do
-            redis.not_nil!.del("myset")
-            redis.not_nil!.sadd("myset", "Hello", "World")
-            redis.not_nil!.scard("myset").should eq(2)
-          end
-        else
-          pending ":redis is not running: #scard"
-        end
-
-        if redis_is_running
-          it "#sismember" do
-            redis.not_nil!.del("key1")
-            redis.not_nil!.sadd("key1", "a")
-            redis.not_nil!.sismember("key1", "a").should eq(1)
-            redis.not_nil!.sismember("key1", "b").should eq(0)
-          end
-        else
-          pending ":redis is not running: #sismember"
-        end
-
-        if redis_is_running
-          it "#srem" do
-            redis.not_nil!.del("myset")
-            redis.not_nil!.sadd("myset", "Hello", "World")
-            redis.not_nil!.srem("myset", "Hello").should eq(1)
-            redis.not_nil!.smembers("myset").should eq(["World"])
-
-            redis.not_nil!.sadd("myset", ["Hello", "World", "Foo"])
-            redis.not_nil!.srem("myset", ["Hello", "Foo"]).should eq(2)
-            redis.not_nil!.smembers("myset").should eq(["World"])
-          end
-        else
-          pending ":redis is not running: #srem"
-        end
-
-        if redis_is_running
-          it "#sdiff" do
-            redis.not_nil!.del("key1", "key2")
-            redis.not_nil!.sadd("key1", "a", "b", "c")
-            redis.not_nil!.sadd("key2", "c", "d", "e")
-            sort(redis.not_nil!.sdiff("key1", "key2")).should eq(["a", "b"])
-          end
-        else
-          pending ":redis is not running: #sdiff"
-        end
-
-        if redis_is_running
-          it "#spop" do
-            redis.not_nil!.del("myset")
-            redis.not_nil!.sadd("myset", "one")
-            redis.not_nil!.spop("myset").should eq("one")
-            redis.not_nil!.smembers("myset").should eq([] of Redis::RedisValue)
-            # Redis 3.0 should have received the "count" argument, but hasn't.
-            #
-            # redis.not_nil!.sadd("myset", "one", "two")
-            # sort(redis.not_nil!.spop("myset", count: 2)).should eq(["one", "two"])
-
-            redis.not_nil!.del("myset")
-            redis.not_nil!.spop("myset").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #spop"
-        end
-
-        if redis_is_running
-          it "#sdiffstore" do
-            redis.not_nil!.del("key1", "key2", "destination")
-            redis.not_nil!.sadd("key1", "a", "b", "c")
-            redis.not_nil!.sadd("key2", "c", "d", "e")
-            redis.not_nil!.sdiffstore("destination", "key1", "key2").should eq(2)
-            sort(redis.not_nil!.smembers("destination")).should eq(["a", "b"])
-          end
-        else
-          pending ":redis is not running: #sdiffstore"
-        end
-
-        if redis_is_running
-          it "#sinter" do
-            redis.not_nil!.del("key1", "key2")
-            redis.not_nil!.sadd("key1", "a", "b", "c")
-            redis.not_nil!.sadd("key2", "c", "d", "e")
-            redis.not_nil!.sinter("key1", "key2").should eq(["c"])
-          end
-        else
-          pending ":redis is not running: #sinter"
-        end
-
-        if redis_is_running
-          it "#sinterstore" do
-            redis.not_nil!.del("key1", "key2", "destination")
-            redis.not_nil!.sadd("key1", "a", "b", "c")
-            redis.not_nil!.sadd("key2", "c", "d", "e")
-            redis.not_nil!.sinterstore("destination", "key1", "key2").should eq(1)
-            redis.not_nil!.smembers("destination").should eq(["c"])
-          end
-        else
-          pending ":redis is not running: #sinterstore"
-        end
-
-        if redis_is_running
-          it "#sunion" do
-            redis.not_nil!.del("key1", "key2")
-            redis.not_nil!.sadd("key1", "a", "b")
-            redis.not_nil!.sadd("key2", "c", "d")
-            sort(redis.not_nil!.sunion("key1", "key2")).should eq(["a", "b", "c", "d"])
-          end
-        else
-          pending ":redis is not running: #sunion"
-        end
-
-        if redis_is_running
-          it "#sunionstore" do
-            redis.not_nil!.del("key1", "key2", "destination")
-            redis.not_nil!.sadd("key1", "a", "b")
-            redis.not_nil!.sadd("key2", "c", "d")
-            redis.not_nil!.sunionstore("destination", "key1", "key2").should eq(4)
-            sort(redis.not_nil!.smembers("destination")).should eq(["a", "b", "c", "d"])
-          end
-        else
-          pending ":redis is not running: #sunionstore"
-        end
-
-        if redis_is_running
-          it "#smove" do
-            redis.not_nil!.del("key1", "key2", "destination")
-            redis.not_nil!.sadd("key1", "a", "b")
-            redis.not_nil!.sadd("key2", "c")
-            redis.not_nil!.smove("key1", "key2", "b").should eq(1)
-            redis.not_nil!.smembers("key1").should eq(["a"])
-            sort(redis.not_nil!.smembers("key2")).should eq(["b", "c"])
-          end
-        else
-          pending ":redis is not running: #smove"
-        end
-
-        if redis_is_running
-          it "#srandmember" do
-            redis.not_nil!.del("key1", "key2", "destination")
-            redis.not_nil!.sadd("key1", "a")
-            redis.not_nil!.srandmember("key1", 1).should eq(["a"])
-          end
-        else
-          pending ":redis is not running: #srandmember"
-        end
-
-        describe "#sscan" do
-          if redis_is_running
-            it "no options" do
-              redis.not_nil!.del("myset")
-              redis.not_nil!.sadd("myset", "a", "b")
-              new_cursor, keys = redis.not_nil!.sscan("myset", 0)
-              new_cursor.should eq("0")
-              sort(keys).should eq(["a", "b"])
-            end
-          else
-            pending ":redis is not running: no options"
-          end
-
-          if redis_is_running
-            it "with match" do
-              redis.not_nil!.del("myset")
-              redis.not_nil!.sadd("myset", "foo", "bar", "foo2", "foo3")
-              _new_cursor, keys = redis.not_nil!.sscan("myset", 0, "foo*", 2)
-              keys.is_a?(Array).should be_true
-              array(keys).size.should be > 0
-            end
-          else
-            pending ":redis is not running: with match"
-          end
-
-          if redis_is_running
-            it "with match and count" do
-              redis.not_nil!.del("myset")
-              redis.not_nil!.sadd("myset", "foo", "bar", "baz")
-              new_cursor, keys = redis.not_nil!.sscan("myset", 0, "*a*", 1)
-              new_cursor = new_cursor.as(String)
-              new_cursor.to_i.should be > 0
-              keys.is_a?(Array).should be_true
-              # TODO SW: This assertion fails randomly
-              # array(keys).size.should be > 0
-            end
-          else
-            pending ":redis is not running: with match and count"
-          end
-
-          if redis_is_running
-            it "with match and count at once" do
-              redis.not_nil!.del("myset")
-              redis.not_nil!.sadd("myset", "foo", "bar", "baz")
-              new_cursor, keys = redis.not_nil!.sscan("myset", 0, "*a*", 10)
-              new_cursor.should eq("0")
-              keys.is_a?(Array).should be_true
-              array(keys).sort.should eq(["bar", "baz"])
-            end
-          else
-            pending ":redis is not running: with match and count at once"
-          end
-        end
-      end
-
-      describe "hashes" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#hset / #hget" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "a", "434")
-            redis.not_nil!.hget("myhash", "a").should eq("434")
-            redis.not_nil!.hset("myhash", "b", "435")
-            redis.not_nil!.hget("myhash", "b").should eq("435")
-          end
-        else
-          pending ":redis is not running: #hset / #hget"
-        end
-
-        if redis_is_running
-          it "#hgetall" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "a", "123")
-            redis.not_nil!.hset("myhash", "b", "456")
-            redis.not_nil!.hgetall("myhash").should eq({"a" => "123", "b" => "456"})
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hgetall("myhash").should eq({} of String => String)
-          end
-        else
-          pending ":redis is not running: #hgetall"
-        end
-
-        if redis_is_running
-          it "#hdel" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "foo")
-            redis.not_nil!.hdel("myhash", "field1").should eq(1)
-            redis.not_nil!.hget("myhash", "field1").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #hdel"
-        end
-
-        if redis_is_running
-          it "#hexists" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "foo")
-            redis.not_nil!.hexists("myhash", "field1").should eq(1)
-            redis.not_nil!.hexists("myhash", "field2").should eq(0)
-          end
-        else
-          pending ":redis is not running: #hexists"
-        end
-
-        if redis_is_running
-          it "#hincrby" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "1")
-            redis.not_nil!.hincrby("myhash", "field1", "3").should eq(4)
-          end
-        else
-          pending ":redis is not running: #hincrby"
-        end
-
-        if redis_is_running
-          it "#hincrbyfloat" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "10.50")
-            redis.not_nil!.hincrbyfloat("myhash", "field1", "0.1").should eq("10.6")
-          end
-        else
-          pending ":redis is not running: #hincrbyfloat"
-        end
-
-        if redis_is_running
-          it "#hkeys" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "1")
-            redis.not_nil!.hset("myhash", "field2", "2")
-            redis.not_nil!.hkeys("myhash").should eq(["field1", "field2"])
-          end
-        else
-          pending ":redis is not running: #hkeys"
-        end
-
-        if redis_is_running
-          it "#hlen" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "field1", "1")
-            redis.not_nil!.hset("myhash", "field2", "2")
-            redis.not_nil!.hlen("myhash").should eq(2)
-          end
-        else
-          pending ":redis is not running: #hlen"
-        end
-
-        if redis_is_running
-          it "#hmget" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "a", "123")
-            redis.not_nil!.hset("myhash", "b", "456")
-            redis.not_nil!.hmget("myhash", "a", "b").should eq(["123", "456"])
-            redis.not_nil!.hmget("myhash", ["a", "b"]).should eq(["123", "456"])
-          end
-        else
-          pending ":redis is not running: #hmget"
-        end
-
-        if redis_is_running
-          it "#hmset" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hmset("myhash", {"field1": "a", "field2": 2})
-            redis.not_nil!.hget("myhash", "field1").should eq("a")
-            redis.not_nil!.hget("myhash", "field2").should eq("2")
-          end
-        else
-          pending ":redis is not running: #hmset"
-        end
-
-        describe "#hscan" do
+    {nil, "my_namespace"}.each do |namespace|
+      context "(namespace: #{namespace})" do
+        describe "keys" do
           if redis_is_running
             redis = namespace ? Redis.new(namespace: namespace) : Redis.new
           end
 
           if redis_is_running
-            it "no options" do
-              redis.not_nil!.del("myhash")
-              redis.not_nil!.hmset("myhash", {"field1": "a", "field2": "b"})
-              new_cursor, keys = redis.not_nil!.hscan("myhash", 0)
-              new_cursor.should eq("0")
-              keys.should eq({"field1" => "a", "field2" => "b"})
+            it "#del" do
+              redis.not_nil!.set("foo", "test")
+              redis.not_nil!.del("foo")
+              redis.not_nil!.get("foo").should eq(nil)
+
+              redis.not_nil!.mset({"foo1" => "bar1", "foo2" => "bar2"})
+              redis.not_nil!.del(["foo1", "foo2"]).should eq(2)
             end
           else
-            pending ":redis is not running: #hscan"
+            pending ":redis is not running: #del"
           end
 
           if redis_is_running
-            it "with match" do
-              redis.not_nil!.del("myhash")
-              redis.not_nil!.hmset("myhash", {"foo": "a", "bar": "b"})
-              new_cursor, keys = redis.not_nil!.hscan("myhash", 0, "f*")
-              new_cursor.should eq("0")
-              keys.should eq({"foo" => "a"})
+            it "converts keys to strings" do
+              redis.not_nil!.set(:foo, "hello")
+              redis.not_nil!.set(123456, 7)
+              redis.not_nil!.get("foo").should eq("hello")
+              redis.not_nil!.get("123456").should eq("7")
             end
           else
-            pending ":redis is not running: #hscan"
-          end
-
-          # pending: hscan doesn't handle COUNT strictly
-          # it "#hscan with match and count" do
-          # end
-
-          if redis_is_running
-            it "with match and count at once" do
-              redis.not_nil!.del("myhash")
-              redis.not_nil!.hmset("myhash", {"foo": "a", "bar": "b", "baz": "c"})
-              new_cursor, keys = redis.not_nil!.hscan("myhash", 0, "*a*", 1024)
-              new_cursor.should eq("0")
-              keys.keys.sort!.should eq(["bar", "baz"])
-            end
-          else
-            pending ":redis is not running: #hscan"
-          end
-        end
-
-        if redis_is_running
-          it "#hsetnx" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hsetnx("myhash", "foo", "setnxed").should eq(1)
-            redis.not_nil!.hget("myhash", "foo").should eq("setnxed")
-            redis.not_nil!.hsetnx("myhash", "foo", "setnxed2").should eq(0)
-            redis.not_nil!.hget("myhash", "foo").should eq("setnxed")
-          end
-        else
-          pending ":redis is not running: #hsetnx"
-        end
-
-        if redis_is_running
-          it "#hvals" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "a", "123")
-            redis.not_nil!.hset("myhash", "b", "456")
-            redis.not_nil!.hvals("myhash").should eq(["123", "456"])
-          end
-        else
-          pending ":redis is not running: #hvals"
-        end
-      end
-
-      describe "sorted sets" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#zadd / zrange" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
-            redis.not_nil!.zadd("myzset", [1, "uno"]).should eq(1)
-            redis.not_nil!.zadd("myzset", 2, "two", 3, "three").should eq(2)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
-          end
-        else
-          pending ":redis is not running: #zadd / zrange"
-        end
-
-        if redis_is_running
-          it "#zadd / zrange with xx" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
-            redis.not_nil!.zadd("myzset", 11, "one", xx: true).should eq(0)
-            redis.not_nil!.zadd("myzset", 2, "two", xx: true).should eq(0)
-            redis.not_nil!.zadd("myzset", 3, "three", xx: false).should eq(1)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3", "one", "11"])
-          end
-        else
-          pending ":redis is not running: #zadd / zrange with xx"
-        end
-
-        if redis_is_running
-          it "#zadd / zrange with nx" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
-            redis.not_nil!.zadd("myzset", 11, "one", nx: true).should eq(0)
-            redis.not_nil!.zadd("myzset", 2, "two", nx: true).should eq(1)
-            redis.not_nil!.zadd("myzset", 3, "three", nx: false).should eq(1)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "two", "2", "three", "3"])
-          end
-        else
-          pending ":redis is not running: #zadd / zrange with nx"
-        end
-
-        if redis_is_running
-          it "#zadd / zrange with ch" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", ch: true).should eq(1)
-            redis.not_nil!.zadd("myzset", 11, "one", ch: true).should eq(1)
-            redis.not_nil!.zadd("myzset", 2, "two", ch: true).should eq(1)
-            redis.not_nil!.zadd("myzset", 3, "three", ch: false).should eq(1)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3", "one", "11"])
-          end
-        else
-          pending ":redis is not running: #zadd / zrange with ch"
-        end
-
-        if redis_is_running
-          it "#zadd / zrange with incr" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", incr: true).should eq("1")
-            redis.not_nil!.zadd("myzset", 11, "one", incr: true).should eq("12")
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "12"])
-          end
-        else
-          pending ":redis is not running: #zadd / zrange with incr"
-        end
-
-        if redis_is_running
-          it "#zrangebylex" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
-            redis.not_nil!.zrangebylex("myzset", "-", "[c").should eq(["a", "b", "c"])
-            redis.not_nil!.zrangebylex("myzset", "-", "(c").should eq(["a", "b"])
-            redis.not_nil!.zrangebylex("myzset", "[aaa", "(g").should eq(["b", "c", "d", "e", "f"])
-            redis.not_nil!.zrangebylex("myzset", "[aaa", "(g", limit: [0, 4]).should eq(["b", "c", "d", "e"])
-          end
-        else
-          pending ":redis is not running: #zrangebylex"
-        end
-
-        if redis_is_running
-          it "#zrangebyscore" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrangebyscore("myzset", "-inf", "+inf").should eq(["one", "two", "three"])
-            redis.not_nil!.zrangebyscore("myzset", "-inf", "+inf", limit: [0, 2]).should eq(["one", "two"])
-          end
-        else
-          pending ":redis is not running: #zrangebyscore"
-        end
-
-        if redis_is_running
-          it "#zrevrange" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrevrange("myzset", 0, -1).should eq(["three", "two", "one"])
-            redis.not_nil!.zrevrange("myzset", 2, 3).should eq(["one"])
-            redis.not_nil!.zrevrange("myzset", -2, -1).should eq(["two", "one"])
-          end
-        else
-          pending ":redis is not running: #zrevrange"
-        end
-
-        if redis_is_running
-          it "#zrevrangebylex" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
-            redis.not_nil!.zrevrangebylex("myzset", "[c", "-").should eq(["c", "b", "a"])
-            redis.not_nil!.zrevrangebylex("myzset", "(c", "-").should eq(["b", "a"])
-            redis.not_nil!.zrevrangebylex("myzset", "(g", "[aaa").should eq(["f", "e", "d", "c", "b"])
-            redis.not_nil!.zrevrangebylex("myzset", "+", "-", limit: [1, 1]).should eq(["f"])
-          end
-        else
-          pending ":redis is not running: #zrevrangebylex"
-        end
-
-        if redis_is_running
-          it "#zrevrangebyscore" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrevrangebyscore("myzset", "+inf", "-inf").should eq(["three", "two", "one"])
-            redis.not_nil!.zrevrangebyscore("myzset", "+inf", "-inf", limit: [0, 2]).should eq(["three", "two"])
-          end
-        else
-          pending ":redis is not running: #zrevrangebyscore"
-        end
-
-        if redis_is_running
-          it "#zscore" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 2, "two")
-            redis.not_nil!.zscore("myzset", "two").should eq("2")
-          end
-        else
-          pending ":redis is not running: #zscore"
-        end
-
-        if redis_is_running
-          it "#zcard" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 2, "two", 3, "three")
-            redis.not_nil!.zcard("myzset").should eq(2)
-          end
-        else
-          pending ":redis is not running: #zcard"
-        end
-
-        if redis_is_running
-          it "#zcount" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zcount("myzset", "-inf", "+inf").should eq(3)
-            redis.not_nil!.zcount("myzset", "(1", "3").should eq(2)
-          end
-        else
-          pending ":redis is not running: #zcount"
-        end
-
-        if redis_is_running
-          it "#zlexcount" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
-            redis.not_nil!.zlexcount("myzset", "-", "+").should eq(7)
-            redis.not_nil!.zlexcount("myzset", "[b", "[f").should eq(5)
-          end
-        else
-          pending ":redis is not running: #zlexcount"
-        end
-
-        if redis_is_running
-          it "#zrank" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrank("myzset", "one").should eq(0)
-            redis.not_nil!.zrank("myzset", "three").should eq(2)
-            redis.not_nil!.zrank("myzset", "four").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #zrank"
-        end
-
-        describe "zscan" do
-          if redis_is_running
-            it "no options" do
-              redis.not_nil!.del("myset")
-              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-              new_cursor, keys = redis.not_nil!.zscan("myzset", 0)
-              new_cursor.should eq("0")
-              keys.should eq(["one", "1", "two", "2", "three", "3"])
-            end
-          else
-            pending ":redis is not running: no options"
+            pending ":redis is not running: converts keys to strings"
           end
 
           if redis_is_running
-            it "with match" do
-              redis.not_nil!.del("myzset")
-              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-              new_cursor, keys = redis.not_nil!.zscan("myzset", 0, "t*")
-              new_cursor.should eq("0")
-              keys.is_a?(Array).should be_true
-              # extract odd elements for keys because zscan returns (key, val) as a single list
-              keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
-              keys.should eq(["two", "three"])
+            it "#rename" do
+              redis.not_nil!.del("foo", "bar")
+              redis.not_nil!.set("foo", "test")
+              redis.not_nil!.rename("foo", "bar")
+              redis.not_nil!.get("bar").should eq("test")
             end
           else
-            pending ":redis is not running: with match"
+            pending ":redis is not running: #rename"
           end
-
-          # pending: zscan doesn't handle COUNT strictly
-          # it "#zscan with match and count" do
-          # end
 
           if redis_is_running
-            it "with match and count at once" do
-              redis.not_nil!.del("myzset")
-              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-              new_cursor, keys = redis.not_nil!.zscan("myzset", 0, "t*", 1024)
-              new_cursor.should eq("0")
-              keys.is_a?(Array).should be_true
-              # extract odd elements for keys because zscan returns (key, val) as a single list
-              keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
-              keys.should eq(["two", "three"])
+            it "#renamenx" do
+              redis.not_nil!.set("foo", "Hello")
+              redis.not_nil!.set("bar", "world")
+              redis.not_nil!.renamenx("foo", "bar").should eq(0)
+              redis.not_nil!.get("bar").should eq("world")
+
+              client_traces, _server_traces = FindJson.from_io(memory)
+              # Spot Check some traces here...
+              client_traces.size.should eq 4
+              client_traces[0]["spans"][0]["name"].should eq "Redis: GET #{[namespace, "bar"].compact!.join("::")}"
+              client_traces[0]["spans"][0]["attributes"]["db.system"].should eq "redis"
+              client_traces[0]["spans"][0]["attributes"]["db.statement"].should eq "GET #{[namespace, "bar"].compact!.join("::")}"
+              client_traces[0]["spans"][0]["attributes"]["net.transport"].should eq "ip_tcp"
             end
           else
-            pending ":redis is not running: with match and count at once"
+            pending ":redis is not running: #renamenx"
           end
-        end
 
-        if redis_is_running
-          it "#zrevrank" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrevrank("myzset", "one").should eq(2)
-            redis.not_nil!.zrevrank("myzset", "three").should eq(0)
-            redis.not_nil!.zrevrank("myzset", "four").should eq(nil)
-          end
-        else
-          pending ":redis is not running: #zrevrank"
-        end
-
-        if redis_is_running
-          it "#zincrby" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one")
-            redis.not_nil!.zincrby("myzset", 2, "one").should eq("3")
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "3"])
-          end
-        else
-          pending ":redis is not running: #zincrby"
-        end
-
-        if redis_is_running
-          it "#zrem" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zrem("myzset", "two").should eq(1)
-            redis.not_nil!.zcard("myzset").should eq(2)
-          end
-        else
-          pending ":redis is not running: #zrem"
-        end
-
-        if redis_is_running
-          it "#zremrangebylex" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 0, "aaaa", 0, "b", 0, "c", 0, "d", 0, "e")
-            redis.not_nil!.zadd("myzset", 0, "foo", 0, "zap", 0, "zip", 0, "ALPHA", 0, "alpha")
-            redis.not_nil!.zremrangebylex("myzset", "[alpha", "[omega")
-            redis.not_nil!.zrange("myzset", 0, -1).should eq(["ALPHA", "aaaa", "zap", "zip"])
-          end
-        else
-          pending ":redis is not running: #zremrangebylex"
-        end
-
-        if redis_is_running
-          it "#zremrangebyrank" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zremrangebyrank("myzset", 0, 1).should eq(2)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3"])
-          end
-        else
-          pending ":redis is not running: #zremrangebyrank"
-        end
-
-        if redis_is_running
-          it "#zremrangebyscore" do
-            redis.not_nil!.del("myzset")
-            redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zremrangebyscore("myzset", "-inf", "(2").should eq(1)
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3"])
-          end
-        else
-          pending ":redis is not running: #zremrangebyscore"
-        end
-
-        if redis_is_running
-          it "#zinterstore" do
-            redis.not_nil!.del("zset1", "zset2", "zset3")
-            redis.not_nil!.zadd("zset1", 1, "one", 2, "two")
-            redis.not_nil!.zadd("zset2", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zinterstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(2)
-            redis.not_nil!.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "two", "10"])
-          end
-        else
-          pending ":redis is not running: #zinterstore"
-        end
-
-        if redis_is_running
-          it "#zunionstore" do
-            redis.not_nil!.del("zset1", "zset2", "zset3")
-            redis.not_nil!.zadd("zset1", 1, "one", 2, "two")
-            redis.not_nil!.zadd("zset2", 1, "one", 2, "two", 3, "three")
-            redis.not_nil!.zunionstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(3)
-            redis.not_nil!.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "three", "9", "two", "10"])
-          end
-        else
-          pending ":redis is not running: #zunionstore"
-        end
-      end
-
-      describe "#pipelined" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "executes the commands in the block and returns the results" do
-            futures = [] of Redis::Future
-            results = redis.not_nil!.pipelined do |pipeline|
-              pipeline.set("foo", "new value")
-              futures << pipeline.get("foo")
+          if redis_is_running
+            it "#randomkey" do
+              redis.not_nil!.set("foo", "Hello")
+              redis.not_nil!.randomkey.should_not be_nil
             end
-            results[1].should eq("new value")
-            futures[0].value.should eq("new value")
-
-            _client_traces, server_traces = FindJson.from_io(memory)
-            server_traces[0]["spans"][0]["name"].should eq "Redis: SET #{[namespace, "foo"].compact.join("::")}"
-            server_traces[2]["spans"][0]["name"].should eq "Redis::Future#value="
-            server_traces[2]["spans"][0]["attributes"]["db.redis.future.value"].should eq "OK"
-            server_traces[2]["spans"][0]["parentSpanId"].should eq server_traces[0]["spans"][0]["spanId"]
-            server_traces[3]["spans"][0]["attributes"]["db.redis.future.value"].should eq "new value"
-            server_traces[3]["spans"][0]["parentSpanId"].should eq server_traces[1]["spans"][0]["spanId"]
+          else
+            pending ":redis is not running: #randomkey"
           end
-        else
-          pending ":redis is not running: executes the commands in the block and returns the results"
-        end
 
-        if redis_is_running
-          it "raises an exception if we call methods on the Redis object" do
-            redis.not_nil!.pipelined do |_pipeline|
-              expect_raises Redis::Error do
-                redis.not_nil!.set("foo", "bar")
+          if redis_is_running
+            it "#exists" do
+              redis.not_nil!.del("foo")
+              redis.not_nil!.exists("foo").should eq(0)
+              redis.not_nil!.set("foo", "test")
+              redis.not_nil!.exists("foo").should eq(1)
+            end
+          else
+            pending ":redis is not running: #exists"
+          end
+
+          if redis_is_running
+            it "#keys" do
+              redis.not_nil!.set("callmemaybe", 1)
+              redis.not_nil!.keys("callmemaybe").should eq(["callmemaybe"])
+            end
+          else
+            pending ":redis is not running: #keys"
+          end
+
+          describe "#sort" do
+            if redis_is_running
+              it "sorts the container" do
+                redis.not_nil!.del("mylist")
+                redis.not_nil!.rpush("mylist", "1", "3", "2")
+                redis.not_nil!.sort("mylist").should eq(["1", "2", "3"])
+                redis.not_nil!.sort("mylist", order: "DESC").should eq(["3", "2", "1"])
               end
-            end
-          end
-        else
-          pending ":redis is not running: raises an exception if we call methods on the Redis object"
-        end
-
-        if redis_is_running
-          it "work with hgetall" do
-            redis.not_nil!.del("myhash")
-            redis.not_nil!.hset("myhash", "a", "123")
-            redis.not_nil!.hset("myhash", "b", "456")
-
-            h = redis.not_nil!.pipelined do |pipeline|
-              pipeline.exists("myhash")
-              pipeline.hgetall("myhash")
-            end
-
-            h.should eq([1, ["a", "123", "b", "456"]])
-          end
-        else
-          pending ":redis is not running: work with hgetall"
-        end
-      end
-
-      describe "hyperloglog" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#pfadd / #pfcount" do
-            redis.not_nil!.del("hll")
-            redis.not_nil!.pfadd("hll", "a", "b", "c", "d", "e", "f", "g").should eq(1)
-            redis.not_nil!.pfcount("hll").should eq(7)
-          end
-        else
-          pending ":redis is not running: #pfadd / #pfcount"
-        end
-
-        if redis_is_running
-          it "#pfmerge" do
-            redis.not_nil!.del("hll1", "hll2", "hll3")
-            redis.not_nil!.pfadd("hll1", "foo", "bar", "zap", "a")
-            redis.not_nil!.pfadd("hll2", "a", "b", "c", "foo")
-            redis.not_nil!.pfmerge("hll3", "hll1", "hll2").should eq("OK")
-            redis.not_nil!.pfcount("hll3").should eq(6)
-          end
-        else
-          pending ":redis is not running: #pfmerge"
-        end
-      end
-
-      describe "#info" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "returns server data" do
-            x = redis.not_nil!.info
-            x.size.should be >= 70
-
-            x = redis.not_nil!.info("cpu")
-            (4..8).should contain(x.size)
-
-            redis.not_nil!.info["redis_version"].should_not be_nil
-          end
-        else
-          pending ":redis is not running: returns server data"
-        end
-      end
-
-      describe "#multi" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "executes the commands in the block and returns the results" do
-            futures = [] of Redis::Future
-            results = redis.not_nil!.multi do |multi|
-              multi.set("foo", "new value")
-              futures << multi.get("foo")
-            end
-            results[1].should eq("new value")
-            # future.not_nil!
-            futures[0].value.should eq("new value")
-          end
-        else
-          pending ":redis is not running: executes the commands in the block and returns the results"
-        end
-
-        if redis_is_running
-          it "does not execute the commands in the block upon #discard" do
-            redis.not_nil!.set("foo", "initial value")
-            results = redis.not_nil!.multi do |multi|
-              multi.set("foo", "new value")
-              multi.discard
-            end
-            redis.not_nil!.get("foo").should eq("initial value")
-            results.should eq([] of Redis::RedisValue)
-          end
-        else
-          pending ":redis is not running: does not execute the commands in the block upon #discard"
-        end
-
-        if redis_is_running
-          it "performs optimistic locking with #watch" do
-            redis.not_nil!.set("foo", "1")
-            current_value = redis.not_nil!.get("foo").not_nil!
-            redis.not_nil!.watch("foo")
-            redis.not_nil!.multi do |multi|
-              other_redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-              other_redis.not_nil!.set("foo", "value set by other client")
-              multi.set("foo", current_value + "2")
-            end
-            redis.not_nil!.get("foo").should eq("value set by other client")
-          end
-        else
-          pending ":redis is not running: performs optimistic locking with #watch"
-        end
-
-        if redis_is_running
-          it "#watch" do
-            redis.not_nil!.set("foo", "1")
-            redis.not_nil!.watch("foo")
-            redis.not_nil!.unwatch
-          end
-        else
-          pending ":redis is not running: #watch"
-        end
-
-        if redis_is_running
-          it "raises an exception if we call methods on the Redis object" do
-            redis.not_nil!.multi do |_multi|
-              expect_raises Redis::Error do
-                redis.not_nil!.set("foo", "bar")
-              end
-            end
-          end
-        else
-          pending ":redis is not running: raises an exception if we call methods on the Redis object"
-        end
-
-        if redis_is_running
-          it "zadd works in multi" do
-            redis.not_nil!.del("myzset")
-
-            redis.not_nil!.multi do |multi|
-              multi.zadd("myzset", 1.0, "one")
-              multi.zadd("myzset", [1, "uno"])
-              multi.zadd("myzset", 2, "two", 3, "three")
-            end
-
-            redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
-          end
-        else
-          pending ":redis is not running: zadd works in multi"
-        end
-      end
-
-      describe "LUA scripting" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        describe "#eval" do
-          if redis_is_running
-            it "executes the LUA script" do
-              keys = ["key1", "key2"] of Redis::RedisValue
-              args = ["first", "second"] of Redis::RedisValue
-              result = redis.not_nil!.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", keys, args)
-              result.should eq(["key1", "key2", "first", "second"])
-            end
-          else
-            pending ":redis is not running: executes the LUA script"
-          end
-
-          if redis_is_running
-            it "handles different return types" do
-              keys = ["key1", "key2"] of Redis::RedisValue
-              args = ["first", "second"] of Redis::RedisValue
-              result = redis.not_nil!.eval("return KEYS[1]", keys, args)
-              result.should eq("key1")
-            end
-          else
-            pending ":redis is not running: handles different return types"
-          end
-        end
-
-        describe "#script_load / #eval_sha" do
-          if redis_is_running
-            it "registers a LUA script and calls it" do
-              sha1 = redis.not_nil!.script_load("return {KEYS[1],ARGV[1]}")
-              keys = ["key1", "key2"] of Redis::RedisValue
-              args = ["first", "second"] of Redis::RedisValue
-              result = redis.not_nil!.evalsha(sha1, keys, args)
-              result.should eq(["key1", "first"])
-            end
-          else
-            pending ":redis is not running: registers a LUA script and calls it"
-          end
-
-          if redis_is_running
-            it "handles different return types" do
-              sha1 = redis.not_nil!.script_load("return KEYS[1]")
-              keys = ["key1", "key2"] of Redis::RedisValue
-              args = ["first", "second"] of Redis::RedisValue
-              result = redis.not_nil!.evalsha(sha1, keys, args)
-              result.should eq("key1")
-            end
-          else
-            pending ":redis is not running: handles different return types"
-          end
-        end
-
-        describe "#script_kill" do
-          if redis_is_running
-            it "kills the currently running LUA script" do
-              begin
-                redis.not_nil!.script_kill
-              rescue Redis::Error
-              end
-            end
-          else
-            pending ":redis is not running: kills the currently running LUA script"
-          end
-        end
-
-        describe "#script_exists" do
-          if redis_is_running
-            it "checks if the given LUA scripts exist" do
-              sha1 = redis.not_nil!.script_load("return 10")
-              result = redis.not_nil!.script_exists([sha1, "fffffffffffffff"])
-              result.should eq([1, 0])
-            end
-          else
-            pending ":redis is not running: checks if the given LUA scripts exist"
-          end
-        end
-
-        describe "#script_flush" do
-          if redis_is_running
-            it "flushes the LUA script cache" do
-              sha1 = redis.not_nil!.script_load("return 10")
-              redis.not_nil!.script_flush
-              redis.not_nil!.script_exists([sha1]).should eq([0])
-            end
-          else
-            pending ":redis is not running: flushes the LUA script cache"
-          end
-        end
-      end
-
-      describe "#type" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "returns a value's type as a string" do
-            redis.not_nil!.set("foo", 3)
-            redis.not_nil!.type("foo").should eq("string")
-          end
-        else
-          pending ":redis is not running: returns a value's type as a string"
-        end
-      end
-
-      describe "expiry" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#expire" do
-            redis.not_nil!.set("temp", "3")
-            redis.not_nil!.expire("temp", 2).should eq(1)
-          end
-        else
-          pending ":redis is not running: #expire"
-        end
-
-        if redis_is_running
-          it "#expireat" do
-            redis.not_nil!.set("temp", "3")
-            redis.not_nil!.expireat("temp", 1555555555005).should eq(1)
-            redis.not_nil!.ttl("temp").should be > 3000
-          end
-        else
-          pending ":redis is not running: #expireat"
-        end
-
-        if redis_is_running
-          it "#ttl" do
-            redis.not_nil!.set("temp", "9")
-            redis.not_nil!.ttl("temp").should eq(-1)
-            redis.not_nil!.expire("temp", 3)
-            redis.not_nil!.ttl("temp").should eq(3)
-          end
-        else
-          pending ":redis is not running: #ttl"
-        end
-
-        if redis_is_running
-          it "#pexpire" do
-            redis.not_nil!.set("temp", "3")
-            redis.not_nil!.pexpire("temp", 1000).should eq(1)
-          end
-        else
-          pending ":redis is not running: #pexpire"
-        end
-
-        if redis_is_running
-          it "#pexpireat" do
-            redis.not_nil!.set("temp", "3")
-            timeout = Time.utc(2029, 2, 15, 10, 20, 30)
-            redis.not_nil!.pexpireat("temp", timeout.to_unix_ms).should eq(1)
-            redis.not_nil!.pttl("temp").should be > 2990
-          end
-        else
-          pending ":redis is not running: #pexpireat"
-        end
-
-        if redis_is_running
-          it "#pttl" do
-            redis.not_nil!.set("temp", "9")
-            redis.not_nil!.pttl("temp").should eq(-1)
-            redis.not_nil!.pexpire("temp", 3000)
-            redis.not_nil!.pttl("temp").should be > 2990
-          end
-        else
-          pending ":redis is not running: #pttl"
-        end
-
-        if redis_is_running
-          it "#persist" do
-            redis.not_nil!.set("temp", "9")
-            redis.not_nil!.expire("temp", 3)
-            redis.not_nil!.ttl("temp").should eq(3)
-            redis.not_nil!.persist("temp")
-            redis.not_nil!.ttl("temp").should eq(-1)
-          end
-        else
-          pending ":redis is not running: #persist"
-        end
-      end
-
-      describe "publish / subscribe" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#publish" do
-            redis.not_nil!.publish("mychannel", "my message")
-          end
-        else
-          pending ":redis is not running: #publish"
-        end
-
-        if redis_is_running
-          it "#subscribe / #unsubscribe" do
-            callbacks_received = [] of String
-            redis.not_nil!.subscribe("mychannel") do |on|
-              on.subscribe do |channel, subscriptions|
-                channel.should eq("mychannel")
-                subscriptions.should eq(1)
-                callbacks_received << "subscribe"
-
-                # Send a message to ourselves so that we can test the other callbacks.
-                # We need a second connection to do so.
-                Redis.open do |other_redis|
-                  other_redis.not_nil!.publish("mychannel", "just talking to myself")
-                end
-              end
-
-              on.message do |channel, message|
-                channel.should eq("mychannel")
-                message.should eq("just talking to myself")
-                callbacks_received << "message"
-
-                # Great, we are done.
-                redis.not_nil!.unsubscribe("mychannel")
-              end
-
-              on.unsubscribe do |channel, subscriptions|
-                channel.should eq("mychannel")
-                subscriptions.should eq(0)
-                callbacks_received << "unsubscribe"
-              end
-            end
-
-            callbacks_received.should eq(["subscribe", "message", "unsubscribe"])
-          end
-        else
-          pending ":redis is not running: #subscribe / #unsubscribe"
-        end
-
-        if redis_is_running
-          it "can be used after #unsubscribe" do
-            redis.not_nil!.subscribe("mychannel") do |on|
-              on.subscribe do |c, _s|
-                redis.not_nil!.unsubscribe(c)
-              end
-            end
-            redis.not_nil!.set("temp", "temp1")
-            redis.not_nil!.get("temp").should eq "temp1"
-          end
-        else
-          pending ":redis is not running: can be used after #unsubscribe"
-        end
-
-        if redis_is_running
-          it "use ping in #subscribe" do
-            redis.not_nil!.del("mychannel")
-            res = [] of String
-
-            spawn do
-              redis.not_nil!.subscribe("mychannel") do |on|
-                on.message do |_channel, message|
-                  res << message
-                  res << redis.not_nil!.ping
-                  redis.not_nil!.unsubscribe("mychannel") if res.size >= 4
-                end
-              end
-            end
-
-            Redis.new.publish("mychannel", "11")
-            Redis.new.publish("mychannel", "22")
-
-            sleep 0.1
-            res.should eq ["11", "pong", "22", "pong"]
-          end
-        else
-          pending ":redis is not running: use ping in #subscribe"
-        end
-      end
-
-      describe "punsubscribe" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#psubscribe / #punsubscribe" do
-            callbacks_received = [] of String
-
-            redis.not_nil!.psubscribe("otherchan*") do |on|
-              on.psubscribe do |channel_pattern, subscriptions|
-                channel_pattern.should eq("otherchan*")
-                subscriptions.should eq(1)
-                callbacks_received << "psubscribe"
-
-                # Send a message to ourselves so that we can test the other callbacks.
-                # We need a second connection to do so.
-                Redis.open do |other_redis|
-                  other_redis.not_nil!.publish("otherchannel", "hello subscriber")
-                end
-              end
-
-              on.pmessage do |channel_pattern, channel, message|
-                channel_pattern.should eq("otherchan*")
-                channel.should eq("otherchannel")
-                message.should eq("hello subscriber")
-                callbacks_received << "pmessage"
-
-                # Great, we are done.
-                redis.not_nil!.punsubscribe("otherchan*")
-              end
-
-              on.punsubscribe do |channel_pattern, subscriptions|
-                channel_pattern.should eq("otherchan*")
-                subscriptions.should eq(0)
-                callbacks_received << "punsubscribe"
-              end
-            end
-
-            callbacks_received.should eq(["psubscribe", "pmessage", "punsubscribe"])
-          end
-        else
-          pending ":redis is not running: #psubscribe / #punsubscribe"
-        end
-      end
-
-      describe "OBJECT commands" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#object_refcount" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "Hello", "World")
-            redis.not_nil!.object_refcount("mylist").should eq(1)
-          end
-        else
-          pending ":redis is not running: #object_refcount"
-        end
-
-        if redis_is_running
-          it "#object_encoding" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "Hello", "World")
-            redis.not_nil!.object_encoding("mylist").should eq("quicklist")
-          end
-        else
-          pending ":redis is not running: #object_encoding"
-        end
-
-        if redis_is_running
-          it "#object_idletime" do
-            redis.not_nil!.del("mylist")
-            redis.not_nil!.rpush("mylist", "Hello", "World")
-            redis.not_nil!.object_idletime("mylist").should eq(0)
-          end
-        else
-          pending ":redis is not running: #object_idletime"
-        end
-      end
-
-      describe "GEO commands" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "#geoadd" do
-            redis.not_nil!.geoadd("Nebraska", -96.8308123, 40.8005243, "Lincoln").should eq(1)
-            redis.not_nil!.geoadd("Nebraska", -96.3614327, 41.2915193, "Omaha").should eq(1)
-          end
-        else
-          pending ":redis is not running: #geoadd"
-        end
-
-        if redis_is_running
-          it "#geodist" do
-            redis.not_nil!.geodist("Nebraska", "Lincoln", "Omaha", "mi").should eq("41.8340")
-          end
-        else
-          pending ":redis is not running: #geodist"
-        end
-
-        if redis_is_running
-          it "#geohash" do
-            geohash = redis.not_nil!.geohash("Nebraska", "Lincoln", "Omaha")
-            geohash.should eq(["9z70he9bq80", "9z76zhzsxc0"])
-          end
-        else
-          pending ":redis is not running: #geohash"
-        end
-
-        if redis_is_running
-          it "#geopos" do
-            pos = redis.not_nil!.geopos("Nebraska", "Lincoln")
-            pos.size.should eq(1)
-            pos[0].as(Array(Redis::RedisValue)).size.should eq(2)
-          end
-        else
-          pending ":redis is not running: #geopos"
-        end
-
-        if redis_is_running
-          it "#georadius" do
-            results = redis.not_nil!.georadius("Nebraska", -96.8308123, 40.8005243, 100, "mi")
-            results.size.should eq(2)
-            results.includes?("Lincoln").should be_true
-            results.includes?("Omaha").should be_true
-          end
-        else
-          pending ":redis is not running: #georadius"
-        end
-
-        if redis_is_running
-          it "#georadiusbymember" do
-            results = redis.not_nil!.georadiusbymember("Nebraska", "Lincoln", 100, "mi")
-            results.size.should eq(2)
-            results.includes?("Lincoln").should be_true
-            results.includes?("Omaha").should be_true
-          end
-        else
-          pending ":redis is not running: #georadiusbymember"
-        end
-      end
-
-      describe "large values" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "sends and receives a large value correctly" do
-            redis.not_nil!.del("foo")
-            large_value = "0123456789" * 100_000 # 1 MB
-            redis.not_nil!.set("foo", large_value)
-            redis.not_nil!.get("foo").should eq(large_value)
-          end
-        else
-          pending ":redis is not running: large values"
-        end
-      end
-
-      describe "regression on #keys: compile time error" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        # https://github.com/stefanwille/crystal-redis/issues/100
-        if redis_is_running
-          it "del + key" do
-            redis.not_nil!.set("namespaced::key", 2)
-            redis.not_nil!.keys("namespaced::*").each { |key| redis.not_nil!.del(key) }
-            redis.not_nil!.keys("namespaced::*").size.should eq 0
-
-            redis.not_nil!.del("namespaced::key") # check that this also compile
-          end
-        else
-          pending ":redis is not running: regression on #keys: compile time error"
-        end
-
-        if redis_is_running
-          it "del + keys" do
-            redis.not_nil!.set("namespaced::key", 2)
-            keys = redis.not_nil!.keys("namespaced::*")
-            redis.not_nil!.del(keys)
-            redis.not_nil!.keys("namespaced::*").size.should eq 0
-
-            redis.not_nil!.del(["namespaced::key"]) # check that this also compile
-          end
-        else
-          pending ":redis is not running: regression on #keys: compile time error"
-        end
-      end
-
-      context "namespace" do
-        if redis_is_running
-          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
-        end
-
-        if redis_is_running
-          it "with namespace" do
-            r1 = Redis.new(namespace: "my_namespace")
-            r2 = Redis.new
-            r3 = Redis.new(namespace: "")
-            r2.del("foo")
-            r2.del("my_namespace::foo")
-
-            redis.not_nil!.set("foo", "abc")
-
-            if namespace
-              r1.get("foo").should eq "abc"
-              r2.get("foo").should eq nil
-              r2.get("my_namespace::foo").should eq "abc"
-              r3.get("foo").should eq nil
-              r3.get("my_namespace::foo").should eq "abc"
             else
-              r1.get("foo").should eq nil
-              r2.get("foo").should eq "abc"
-              r2.get("my_namespace::foo").should eq nil
-              r3.get("foo").should eq "abc"
-              r3.get("my_namespace::foo").should eq nil
+              pending ":redis is not running: sorts the container"
+            end
+
+            if redis_is_running
+              it "limit" do
+                redis.not_nil!.del("mylist")
+                redis.not_nil!.rpush("mylist", "1", "3", "2")
+                redis.not_nil!.sort("mylist", limit: [1, 2]).should eq(["2", "3"])
+              end
+            else
+              pending ":redis is not running: limit"
+            end
+
+            if redis_is_running
+              it "by" do
+                redis.not_nil!.del("mylist", "objects", "weights")
+                redis.not_nil!.rpush("mylist", "1", "3", "2")
+                redis.not_nil!.mset({"weight_1" => 1, "weight_2" => 2, "weight_3" => 3})
+                redis.not_nil!.sort("mylist", by: "weights_*").should eq(["1", "2", "3"])
+              end
+            else
+              pending ":redis is not running: by"
+            end
+
+            if redis_is_running
+              it "alpha" do
+                redis.not_nil!.del("mylist")
+                redis.not_nil!.rpush("mylist", "c", "a", "b")
+                redis.not_nil!.sort("mylist", alpha: true).should eq(["a", "b", "c"])
+              end
+            else
+              pending ":redis is not running: alpha"
+            end
+
+            if redis_is_running
+              it "store" do
+                redis.not_nil!.del("mylist", "destination")
+                redis.not_nil!.rpush("mylist", "1", "3", "2")
+                redis.not_nil!.sort("mylist", store: "destination")
+                redis.not_nil!.lrange("destination", 0, 2).should eq(["1", "2", "3"])
+              end
+            else
+              pending ":redis is not running: store"
+            end
+          end
+
+          if redis_is_running
+            it "#dump / #restore" do
+              Redis.open do |inner_redis|
+                inner_redis.not_nil!.set("foo", "9")
+                serialized_value = inner_redis.not_nil!.dump("foo")
+                inner_redis.not_nil!.del("foo")
+                inner_redis.not_nil!.restore("foo", 0, serialized_value).should eq("OK")
+                inner_redis.not_nil!.get("foo").should eq("9")
+                inner_redis.not_nil!.ttl("foo").should eq(-1)
+              end
+            end
+          else
+            pending ":redis is not running: #dump / #restore"
+          end
+        end
+
+        describe "select database" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "select database when connect" do
+              redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
+              redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
+
+              redis1.del("test_database")
+              redis2.del("test_database")
+
+              redis1.set("test_database", "1")
+              redis2.set("test_database", "2")
+
+              redis1.get("test_database").should eq "1"
+              redis2.get("test_database").should eq "2"
+            end
+          else
+            pending ":redis is not running: select database when connect"
+          end
+
+          if redis_is_running
+            it "select database by command" do
+              redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
+              redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
+
+              redis1.del("test_database")
+              redis2.del("test_database")
+
+              redis1.set("test_database", "1")
+              redis2.set("test_database", "2")
+
+              redis.not_nil!.select(1)
+              redis.not_nil!.get("test_database").should eq "1"
+
+              redis.not_nil!.select(2)
+              redis.not_nil!.get("test_database").should eq "2"
+            end
+          else
+            pending ":redis is not running: select database by command"
+          end
+
+          if redis_is_running
+            it "does nothing if current database is the same as given one" do
+              redis.not_nil!.select(2).should eq "OK"
+              redis.not_nil!.select(1).should eq "OK"
+              redis.not_nil!.select(1).should eq "OK"
+              # There is no good way to assert that no command was sent
+            end
+          else
+            pending ":redis is not running: does nothing if current database is the same as given one"
+          end
+        end
+
+        describe "strings" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#set / #get" do
+              redis.not_nil!.set("foo", "test")
+              redis.not_nil!.get("foo").should eq("test")
+            end
+          else
+            pending ":redis is not running: #set / #get"
+          end
+
+          if redis_is_running
+            it "#set options" do
+              redis.not_nil!.set("foo", "test", ex: 7)
+              redis.not_nil!.ttl("foo").should eq(7)
+
+              redis.not_nil!.set("foo", "test", px: 7)
+              redis.not_nil!.ttl("foo").should eq(0)
+
+              redis.not_nil!.set("foo", "test", nx: true)
+
+              redis.not_nil!.set("foo", "test", xx: true)
+            end
+          else
+            pending ":redis is not running: #set options"
+          end
+
+          if redis_is_running
+            it "#mget" do
+              redis.not_nil!.set("foo1", "test1")
+              redis.not_nil!.set("foo2", "test2")
+              redis.not_nil!.mget("foo1", "foo2").should eq(["test1", "test2"])
+              redis.not_nil!.mget(["foo2", "foo1"]).should eq(["test2", "test1"])
+            end
+          else
+            pending ":redis is not running: #mget"
+          end
+
+          if redis_is_running
+            it "#mset" do
+              redis.not_nil!.mset({"foo1" => "bar1", "foo2" => "bar2"})
+              redis.not_nil!.get("foo1").should eq("bar1")
+              redis.not_nil!.get("foo2").should eq("bar2")
+            end
+          else
+            pending ":redis is not running: #mset"
+          end
+
+          if redis_is_running
+            it "#getset" do
+              redis.not_nil!.set("foo", "old")
+              redis.not_nil!.getset("foo", "new").should eq("old")
+              redis.not_nil!.get("foo").should eq("new")
+            end
+          else
+            pending ":redis is not running: #getset"
+          end
+
+          if redis_is_running
+            it "#setex" do
+              redis.not_nil!.setex("foo", 3, "setexed")
+              redis.not_nil!.get("foo").should eq("setexed")
+            end
+          else
+            pending ":redis is not running: #setex"
+          end
+
+          if redis_is_running
+            it "#psetex" do
+              redis.not_nil!.psetex("foo", 3000, "psetexed")
+              redis.not_nil!.get("foo").should eq("psetexed")
+            end
+          else
+            pending ":redis is not running: #psetex"
+          end
+
+          if redis_is_running
+            it "#setnx" do
+              redis.not_nil!.del("foo")
+              redis.not_nil!.setnx("foo", "setnxed").should eq(1)
+              redis.not_nil!.get("foo").should eq("setnxed")
+              redis.not_nil!.setnx("foo", "setnxed2").should eq(0)
+              redis.not_nil!.get("foo").should eq("setnxed")
+            end
+          else
+            pending ":redis is not running: #setnx"
+          end
+
+          if redis_is_running
+            it "#msetnx" do
+              redis.not_nil!.del("key1", "key2", "key3")
+              redis.not_nil!.msetnx({"key1": "hello", "key2": "there"}).should eq(1)
+              redis.not_nil!.get("key1").should eq("hello")
+              redis.not_nil!.get("key2").should eq("there")
+              redis.not_nil!.msetnx({"key2": "keep", "key3": "singing"}).should eq(0)
+              redis.not_nil!.get("key1").should eq("hello")
+              redis.not_nil!.get("key2").should eq("there")
+              redis.not_nil!.get("key3").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #msetnx"
+          end
+
+          if redis_is_running
+            it "#incr" do
+              redis.not_nil!.set("foo", "3")
+              redis.not_nil!.incr("foo").should eq(4)
+            end
+          else
+            pending ":redis is not running: #incr"
+          end
+
+          if redis_is_running
+            it "#decr" do
+              redis.not_nil!.set("foo", "3")
+              redis.not_nil!.decr("foo").should eq(2)
+            end
+          else
+            pending ":redis is not running: #decr"
+          end
+
+          if redis_is_running
+            it "#incrby" do
+              redis.not_nil!.set("foo", "10")
+              redis.not_nil!.incrby("foo", 4).should eq(14)
+            end
+          else
+            pending ":redis is not running: #incrby"
+          end
+
+          if redis_is_running
+            it "#decrby" do
+              redis.not_nil!.set("foo", "10")
+              redis.not_nil!.decrby("foo", 4).should eq(6)
+            end
+          else
+            pending ":redis is not running: #decrby"
+          end
+
+          if redis_is_running
+            it "#incrbyfloat" do
+              redis.not_nil!.set("foo", "10")
+              redis.not_nil!.incrbyfloat("foo", 2.5).should eq("12.5")
+            end
+          else
+            pending ":redis is not running: #incrbyfloat"
+          end
+
+          if redis_is_running
+            it "#append" do
+              redis.not_nil!.set("foo", "hello")
+              redis.not_nil!.append("foo", " world")
+              redis.not_nil!.get("foo").should eq("hello world")
+            end
+          else
+            pending ":redis is not running: #append"
+          end
+
+          if redis_is_running
+            it "#strlen" do
+              redis.not_nil!.set("foo", "Hello world")
+              redis.not_nil!.strlen("foo").should eq(11)
+              redis.not_nil!.del("foo")
+              redis.not_nil!.strlen("foo").should eq(0)
+            end
+          else
+            pending ":redis is not running: #strlen"
+          end
+
+          if redis_is_running
+            it "#getrange" do
+              redis.not_nil!.set("foo", "This is a string")
+              redis.not_nil!.getrange("foo", 0, 3).should eq("This")
+              redis.not_nil!.getrange("foo", -3, -1).should eq("ing")
+            end
+          else
+            pending ":redis is not running: #getrange"
+          end
+
+          if redis_is_running
+            it "#setrange" do
+              redis.not_nil!.set("foo", "Hello world")
+              redis.not_nil!.setrange("foo", 6, "Redis").should eq(11)
+              redis.not_nil!.get("foo").should eq("Hello Redis")
+            end
+          else
+            pending ":redis is not running: #setrange"
+          end
+
+          describe "#scan" do
+            if redis_is_running
+              it "no options" do
+                redis.not_nil!.set("foo", "Hello world")
+                new_cursor, keys = redis.not_nil!.scan(0)
+                new_cursor = new_cursor.as(String)
+                new_cursor.to_i.should be > 0
+                keys.is_a?(Array).should be_true
+              end
+            else
+              pending ":redis is not running: no options"
+            end
+
+            if redis_is_running
+              it "with match" do
+                redis.not_nil!.set("scan.match1", "1")
+                redis.not_nil!.set("scan.match2", "2")
+                new_cursor, keys = redis.not_nil!.scan(0, "scan.match*")
+                new_cursor = new_cursor.as(String)
+                new_cursor.to_i.should be > 0
+                keys.is_a?(Array).should be_true
+                # Here `keys.size` should be 0 or 1 or 2, but I don't know how to test it.
+              end
+            else
+              pending ":redis is not running: with match"
+            end
+
+            if redis_is_running
+              it "with match and count" do
+                redis.not_nil!.set("scan.match1", "1")
+                redis.not_nil!.set("scan.match2", "2")
+                new_cursor, keys = redis.not_nil!.scan(0, "scan.match*", 1)
+                new_cursor = new_cursor.as(String)
+                new_cursor.to_i.should be > 0
+                keys.is_a?(Array).should be_true
+                # Here `keys.size` should be 0 or 1, but I don't know how to test it.
+              end
+            else
+              pending ":redis is not running: with match and count"
+            end
+
+            if redis_is_running
+              it "with match and count at once" do
+                redis.not_nil!.set("scan.match1", "1")
+                redis.not_nil!.set("scan.match2", "2")
+                # assumes that current Redis instance has at most 10M entries
+                new_cursor, keys = redis.not_nil!.scan(0, "scan.match*", 10_000_000)
+                new_cursor.should eq("0")
+                array(keys).sort.should eq(["scan.match1", "scan.match2"])
+              end
+            else
+              pending ":redis is not running: with match and count at once"
+            end
+          end
+        end
+
+        describe "bit operations" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#bitcount" do
+              redis.not_nil!.set("foo", "foobar")
+              redis.not_nil!.bitcount("foo", 0, 0).should eq(4)
+              redis.not_nil!.bitcount("foo", 1, 1).should eq(6)
+            end
+          else
+            pending ":redis is not running: #bitcount"
+          end
+
+          if redis_is_running
+            it "#bitop" do
+              redis.not_nil!.set("key1", "foobar")
+              redis.not_nil!.set("key2", "abcdef")
+              redis.not_nil!.bitop("and", "dest", "key1", "key2").should eq(6)
+              redis.not_nil!.get("dest").should eq("`bc`ab")
+            end
+          else
+            pending ":redis is not running: #bitop"
+          end
+
+          if redis_is_running
+            it "#bitpos" do
+              redis.not_nil!.set("mykey", "0")
+              redis.not_nil!.bitpos("mykey", 1).should eq(2)
+            end
+          else
+            pending ":redis is not running: #bitpos"
+          end
+
+          if redis_is_running
+            it "#getbit / #setbit" do
+              redis.not_nil!.del("mykey")
+              redis.not_nil!.setbit("mykey", 7, 1).should eq(0)
+              redis.not_nil!.getbit("mykey", 0).should eq(0)
+              redis.not_nil!.getbit("mykey", 7).should eq(1)
+              redis.not_nil!.getbit("mykey", 100).should eq(0)
+            end
+          else
+            pending ":redis is not running: #getbit / #setbit"
+          end
+        end
+
+        describe "lists" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#rpush / #lrange" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello").should eq(1)
+              redis.not_nil!.rpush("mylist", "world").should eq(2)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
+              redis.not_nil!.rpush("mylist", "snip", "snip").should eq(4)
+            end
+          else
+            pending ":redis is not running: #rpush / #lrange"
+          end
+
+          if redis_is_running
+            it "#lpush" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.lpush("mylist", "hello").should eq(1)
+              redis.not_nil!.lpush("mylist", ["world"]).should eq(2)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["world", "hello"])
+              redis.not_nil!.lpush("mylist", "snip", "snip").should eq(4)
+            end
+          else
+            pending ":redis is not running: #lpush"
+          end
+
+          if redis_is_running
+            it "#lpushx" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.lpushx("mylist", "hello").should eq(0)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
+              redis.not_nil!.lpush("mylist", "hello")
+              redis.not_nil!.lpushx("mylist", "world").should eq(2)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["world", "hello"])
+            end
+          else
+            pending ":redis is not running: #lpushx"
+          end
+
+          if redis_is_running
+            it "#rpushx" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpushx("mylist", "hello").should eq(0)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpushx("mylist", "world").should eq(2)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
+            end
+          else
+            pending ":redis is not running: #rpushx"
+          end
+
+          if redis_is_running
+            it "#lrem" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "my")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.lrem("mylist", 1, "my").should eq(1)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello", "world"])
+              redis.not_nil!.lrem("mylist", 0, "world").should eq(1)
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["hello"])
+            end
+          else
+            pending ":redis is not running: #lrem"
+          end
+
+          if redis_is_running
+            it "#llen" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.lpush("mylist", "hello")
+              redis.not_nil!.lpush("mylist", "world")
+              redis.not_nil!.llen("mylist").should eq(2)
+            end
+          else
+            pending ":redis is not running: #llen"
+          end
+
+          if redis_is_running
+            it "#lset" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.lset("mylist", 0, "goodbye").should eq("OK")
+              redis.not_nil!.lrange("mylist", 0, 1).should eq(["goodbye", "world"])
+            end
+          else
+            pending ":redis is not running: #lset"
+          end
+
+          if redis_is_running
+            it "#lindex" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.lindex("mylist", 0).should eq("hello")
+              redis.not_nil!.lindex("mylist", 1).should eq("world")
+              redis.not_nil!.lindex("mylist", 2).should eq(nil)
+            end
+          else
+            pending ":redis is not running: #lindex"
+          end
+
+          if redis_is_running
+            it "#lpop" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.lpop("mylist").should eq("hello")
+              redis.not_nil!.lpop("mylist").should eq("world")
+              redis.not_nil!.lpop("mylist").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #lpop"
+          end
+
+          if redis_is_running
+            it "#rpop" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.rpop("mylist").should eq("world")
+              redis.not_nil!.rpop("mylist").should eq("hello")
+              redis.not_nil!.rpop("mylist").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #rpop"
+          end
+
+          if redis_is_running
+            it "#linsert" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello")
+              redis.not_nil!.rpush("mylist", "world")
+              redis.not_nil!.linsert("mylist", :before, "world", "dear").should eq(3)
+              redis.not_nil!.lrange("mylist", 0, 2).should eq(["hello", "dear", "world"])
+            end
+          else
+            pending ":redis is not running: #linsert"
+          end
+
+          if redis_is_running
+            it "#blpop" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.del("myotherlist")
+              redis.not_nil!.rpush("mylist", "hello", "world")
+              redis.not_nil!.blpop(["myotherlist", "mylist"], 1).should eq(["mylist", "hello"])
+            end
+          else
+            pending ":redis is not running: #blpop"
+          end
+
+          if redis_is_running
+            it "#blpop with no data, should not raise" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.del("myotherlist")
+              redis.not_nil!.blpop(["myotherlist", "mylist"], 1).should eq([] of String)
+            end
+          else
+            pending ":redis is not running: #blpop"
+          end
+
+          if redis_is_running
+            it "#ltrim" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "hello", "good", "world")
+              redis.not_nil!.ltrim("mylist", 0, 0).should eq("OK")
+              redis.not_nil!.lrange("mylist", 0, 2).should eq(["hello"])
+            end
+          else
+            pending ":redis is not running: #ltrim"
+          end
+
+          if redis_is_running
+            it "#brpop" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.del("myotherlist")
+              redis.not_nil!.rpush("mylist", "hello", "world")
+              redis.not_nil!.brpop(["myotherlist", "mylist"], 1).should eq(["mylist", "world"])
+
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.brpop(["mylist"], 1).should eq([] of String)
+            end
+          else
+            pending ":redis is not running: #brpop"
+          end
+
+          if redis_is_running
+            it "#brpop with no data, should not raise" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.del("myotherlist")
+              redis.not_nil!.brpop(["myotherlist", "mylist"], 1).should eq([] of String)
+            end
+          else
+            pending ":redis is not running: #brpop"
+          end
+
+          if redis_is_running
+            it "#rpoplpush" do
+              redis.not_nil!.del("source")
+              redis.not_nil!.del("destination")
+              redis.not_nil!.rpush("source", "a", "b", "c")
+              redis.not_nil!.rpush("destination", "1", "2", "3")
+              redis.not_nil!.rpoplpush("source", "destination")
+              redis.not_nil!.lrange("source", 0, 4).should eq(["a", "b"])
+              redis.not_nil!.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
+            end
+          else
+            pending ":redis is not running: #rpoplpush"
+          end
+
+          if redis_is_running
+            it "#brpoplpush" do
+              redis.not_nil!.del("source")
+              redis.not_nil!.del("destination")
+              redis.not_nil!.rpush("source", "a", "b", "c")
+              redis.not_nil!.rpush("destination", "1", "2", "3")
+              redis.not_nil!.brpoplpush("source", "destination", 0)
+              redis.not_nil!.lrange("source", 0, 4).should eq(["a", "b"])
+              redis.not_nil!.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
+
+              # timeout test (#68)
+              redis.not_nil!.del("source")
+              redis.not_nil!.brpoplpush("source", "destination", 1).should eq(nil)
+            end
+          else
+            pending ":redis is not running: #brpoplpush"
+          end
+        end
+
+        describe "sets" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#sadd / #smembers" do
+              redis.not_nil!.del("myset")
+              redis.not_nil!.sadd("myset", "Hello").should eq(1)
+              redis.not_nil!.sadd("myset", "World").should eq(1)
+              redis.not_nil!.sadd("myset", "World").should eq(0)
+              redis.not_nil!.sadd("myset", ["Foo", "Bar"]).should eq(2)
+              sort(redis.not_nil!.smembers("myset")).should eq(["Bar", "Foo", "Hello", "World"])
+            end
+          else
+            pending ":redis is not running: #sadd / #smembers"
+          end
+
+          if redis_is_running
+            it "#scard" do
+              redis.not_nil!.del("myset")
+              redis.not_nil!.sadd("myset", "Hello", "World")
+              redis.not_nil!.scard("myset").should eq(2)
+            end
+          else
+            pending ":redis is not running: #scard"
+          end
+
+          if redis_is_running
+            it "#sismember" do
+              redis.not_nil!.del("key1")
+              redis.not_nil!.sadd("key1", "a")
+              redis.not_nil!.sismember("key1", "a").should eq(1)
+              redis.not_nil!.sismember("key1", "b").should eq(0)
+            end
+          else
+            pending ":redis is not running: #sismember"
+          end
+
+          if redis_is_running
+            it "#srem" do
+              redis.not_nil!.del("myset")
+              redis.not_nil!.sadd("myset", "Hello", "World")
+              redis.not_nil!.srem("myset", "Hello").should eq(1)
+              redis.not_nil!.smembers("myset").should eq(["World"])
+
+              redis.not_nil!.sadd("myset", ["Hello", "World", "Foo"])
+              redis.not_nil!.srem("myset", ["Hello", "Foo"]).should eq(2)
+              redis.not_nil!.smembers("myset").should eq(["World"])
+            end
+          else
+            pending ":redis is not running: #srem"
+          end
+
+          if redis_is_running
+            it "#sdiff" do
+              redis.not_nil!.del("key1", "key2")
+              redis.not_nil!.sadd("key1", "a", "b", "c")
+              redis.not_nil!.sadd("key2", "c", "d", "e")
+              sort(redis.not_nil!.sdiff("key1", "key2")).should eq(["a", "b"])
+            end
+          else
+            pending ":redis is not running: #sdiff"
+          end
+
+          if redis_is_running
+            it "#spop" do
+              redis.not_nil!.del("myset")
+              redis.not_nil!.sadd("myset", "one")
+              redis.not_nil!.spop("myset").should eq("one")
+              redis.not_nil!.smembers("myset").should eq([] of Redis::RedisValue)
+              # Redis 3.0 should have received the "count" argument, but hasn't.
+              #
+              # redis.not_nil!.sadd("myset", "one", "two")
+              # sort(redis.not_nil!.spop("myset", count: 2)).should eq(["one", "two"])
+
+              redis.not_nil!.del("myset")
+              redis.not_nil!.spop("myset").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #spop"
+          end
+
+          if redis_is_running
+            it "#sdiffstore" do
+              redis.not_nil!.del("key1", "key2", "destination")
+              redis.not_nil!.sadd("key1", "a", "b", "c")
+              redis.not_nil!.sadd("key2", "c", "d", "e")
+              redis.not_nil!.sdiffstore("destination", "key1", "key2").should eq(2)
+              sort(redis.not_nil!.smembers("destination")).should eq(["a", "b"])
+            end
+          else
+            pending ":redis is not running: #sdiffstore"
+          end
+
+          if redis_is_running
+            it "#sinter" do
+              redis.not_nil!.del("key1", "key2")
+              redis.not_nil!.sadd("key1", "a", "b", "c")
+              redis.not_nil!.sadd("key2", "c", "d", "e")
+              redis.not_nil!.sinter("key1", "key2").should eq(["c"])
+            end
+          else
+            pending ":redis is not running: #sinter"
+          end
+
+          if redis_is_running
+            it "#sinterstore" do
+              redis.not_nil!.del("key1", "key2", "destination")
+              redis.not_nil!.sadd("key1", "a", "b", "c")
+              redis.not_nil!.sadd("key2", "c", "d", "e")
+              redis.not_nil!.sinterstore("destination", "key1", "key2").should eq(1)
+              redis.not_nil!.smembers("destination").should eq(["c"])
+            end
+          else
+            pending ":redis is not running: #sinterstore"
+          end
+
+          if redis_is_running
+            it "#sunion" do
+              redis.not_nil!.del("key1", "key2")
+              redis.not_nil!.sadd("key1", "a", "b")
+              redis.not_nil!.sadd("key2", "c", "d")
+              sort(redis.not_nil!.sunion("key1", "key2")).should eq(["a", "b", "c", "d"])
+            end
+          else
+            pending ":redis is not running: #sunion"
+          end
+
+          if redis_is_running
+            it "#sunionstore" do
+              redis.not_nil!.del("key1", "key2", "destination")
+              redis.not_nil!.sadd("key1", "a", "b")
+              redis.not_nil!.sadd("key2", "c", "d")
+              redis.not_nil!.sunionstore("destination", "key1", "key2").should eq(4)
+              sort(redis.not_nil!.smembers("destination")).should eq(["a", "b", "c", "d"])
+            end
+          else
+            pending ":redis is not running: #sunionstore"
+          end
+
+          if redis_is_running
+            it "#smove" do
+              redis.not_nil!.del("key1", "key2", "destination")
+              redis.not_nil!.sadd("key1", "a", "b")
+              redis.not_nil!.sadd("key2", "c")
+              redis.not_nil!.smove("key1", "key2", "b").should eq(1)
+              redis.not_nil!.smembers("key1").should eq(["a"])
+              sort(redis.not_nil!.smembers("key2")).should eq(["b", "c"])
+            end
+          else
+            pending ":redis is not running: #smove"
+          end
+
+          if redis_is_running
+            it "#srandmember" do
+              redis.not_nil!.del("key1", "key2", "destination")
+              redis.not_nil!.sadd("key1", "a")
+              redis.not_nil!.srandmember("key1", 1).should eq(["a"])
+            end
+          else
+            pending ":redis is not running: #srandmember"
+          end
+
+          describe "#sscan" do
+            if redis_is_running
+              it "no options" do
+                redis.not_nil!.del("myset")
+                redis.not_nil!.sadd("myset", "a", "b")
+                new_cursor, keys = redis.not_nil!.sscan("myset", 0)
+                new_cursor.should eq("0")
+                sort(keys).should eq(["a", "b"])
+              end
+            else
+              pending ":redis is not running: no options"
+            end
+
+            if redis_is_running
+              it "with match" do
+                redis.not_nil!.del("myset")
+                redis.not_nil!.sadd("myset", "foo", "bar", "foo2", "foo3")
+                _new_cursor, keys = redis.not_nil!.sscan("myset", 0, "foo*", 2)
+                keys.is_a?(Array).should be_true
+                array(keys).size.should be > 0
+              end
+            else
+              pending ":redis is not running: with match"
+            end
+
+            if redis_is_running
+              it "with match and count" do
+                redis.not_nil!.del("myset")
+                redis.not_nil!.sadd("myset", "foo", "bar", "baz")
+                new_cursor, keys = redis.not_nil!.sscan("myset", 0, "*a*", 1)
+                new_cursor = new_cursor.as(String)
+                new_cursor.to_i.should be > 0
+                keys.is_a?(Array).should be_true
+                # TODO SW: This assertion fails randomly
+                # array(keys).size.should be > 0
+              end
+            else
+              pending ":redis is not running: with match and count"
+            end
+
+            if redis_is_running
+              it "with match and count at once" do
+                redis.not_nil!.del("myset")
+                redis.not_nil!.sadd("myset", "foo", "bar", "baz")
+                new_cursor, keys = redis.not_nil!.sscan("myset", 0, "*a*", 10)
+                new_cursor.should eq("0")
+                keys.is_a?(Array).should be_true
+                array(keys).sort.should eq(["bar", "baz"])
+              end
+            else
+              pending ":redis is not running: with match and count at once"
+            end
+          end
+        end
+
+        describe "hashes" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#hset / #hget" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "a", "434")
+              redis.not_nil!.hget("myhash", "a").should eq("434")
+              redis.not_nil!.hset("myhash", "b", "435")
+              redis.not_nil!.hget("myhash", "b").should eq("435")
+            end
+          else
+            pending ":redis is not running: #hset / #hget"
+          end
+
+          if redis_is_running
+            it "#hgetall" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "a", "123")
+              redis.not_nil!.hset("myhash", "b", "456")
+              redis.not_nil!.hgetall("myhash").should eq({"a" => "123", "b" => "456"})
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hgetall("myhash").should eq({} of String => String)
+            end
+          else
+            pending ":redis is not running: #hgetall"
+          end
+
+          if redis_is_running
+            it "#hdel" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "foo")
+              redis.not_nil!.hdel("myhash", "field1").should eq(1)
+              redis.not_nil!.hget("myhash", "field1").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #hdel"
+          end
+
+          if redis_is_running
+            it "#hexists" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "foo")
+              redis.not_nil!.hexists("myhash", "field1").should eq(1)
+              redis.not_nil!.hexists("myhash", "field2").should eq(0)
+            end
+          else
+            pending ":redis is not running: #hexists"
+          end
+
+          if redis_is_running
+            it "#hincrby" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "1")
+              redis.not_nil!.hincrby("myhash", "field1", "3").should eq(4)
+            end
+          else
+            pending ":redis is not running: #hincrby"
+          end
+
+          if redis_is_running
+            it "#hincrbyfloat" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "10.50")
+              redis.not_nil!.hincrbyfloat("myhash", "field1", "0.1").should eq("10.6")
+            end
+          else
+            pending ":redis is not running: #hincrbyfloat"
+          end
+
+          if redis_is_running
+            it "#hkeys" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "1")
+              redis.not_nil!.hset("myhash", "field2", "2")
+              redis.not_nil!.hkeys("myhash").should eq(["field1", "field2"])
+            end
+          else
+            pending ":redis is not running: #hkeys"
+          end
+
+          if redis_is_running
+            it "#hlen" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "field1", "1")
+              redis.not_nil!.hset("myhash", "field2", "2")
+              redis.not_nil!.hlen("myhash").should eq(2)
+            end
+          else
+            pending ":redis is not running: #hlen"
+          end
+
+          if redis_is_running
+            it "#hmget" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "a", "123")
+              redis.not_nil!.hset("myhash", "b", "456")
+              redis.not_nil!.hmget("myhash", "a", "b").should eq(["123", "456"])
+              redis.not_nil!.hmget("myhash", ["a", "b"]).should eq(["123", "456"])
+            end
+          else
+            pending ":redis is not running: #hmget"
+          end
+
+          if redis_is_running
+            it "#hmset" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hmset("myhash", {"field1": "a", "field2": 2})
+              redis.not_nil!.hget("myhash", "field1").should eq("a")
+              redis.not_nil!.hget("myhash", "field2").should eq("2")
+            end
+          else
+            pending ":redis is not running: #hmset"
+          end
+
+          describe "#hscan" do
+            if redis_is_running
+              redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+            end
+
+            if redis_is_running
+              it "no options" do
+                redis.not_nil!.del("myhash")
+                redis.not_nil!.hmset("myhash", {"field1": "a", "field2": "b"})
+                new_cursor, keys = redis.not_nil!.hscan("myhash", 0)
+                new_cursor.should eq("0")
+                keys.should eq({"field1" => "a", "field2" => "b"})
+              end
+            else
+              pending ":redis is not running: #hscan"
+            end
+
+            if redis_is_running
+              it "with match" do
+                redis.not_nil!.del("myhash")
+                redis.not_nil!.hmset("myhash", {"foo": "a", "bar": "b"})
+                new_cursor, keys = redis.not_nil!.hscan("myhash", 0, "f*")
+                new_cursor.should eq("0")
+                keys.should eq({"foo" => "a"})
+              end
+            else
+              pending ":redis is not running: #hscan"
+            end
+
+            # pending: hscan doesn't handle COUNT strictly
+            # it "#hscan with match and count" do
+            # end
+
+            if redis_is_running
+              it "with match and count at once" do
+                redis.not_nil!.del("myhash")
+                redis.not_nil!.hmset("myhash", {"foo": "a", "bar": "b", "baz": "c"})
+                new_cursor, keys = redis.not_nil!.hscan("myhash", 0, "*a*", 1024)
+                new_cursor.should eq("0")
+                keys.keys.sort!.should eq(["bar", "baz"])
+              end
+            else
+              pending ":redis is not running: #hscan"
+            end
+          end
+
+          if redis_is_running
+            it "#hsetnx" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hsetnx("myhash", "foo", "setnxed").should eq(1)
+              redis.not_nil!.hget("myhash", "foo").should eq("setnxed")
+              redis.not_nil!.hsetnx("myhash", "foo", "setnxed2").should eq(0)
+              redis.not_nil!.hget("myhash", "foo").should eq("setnxed")
+            end
+          else
+            pending ":redis is not running: #hsetnx"
+          end
+
+          if redis_is_running
+            it "#hvals" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "a", "123")
+              redis.not_nil!.hset("myhash", "b", "456")
+              redis.not_nil!.hvals("myhash").should eq(["123", "456"])
+            end
+          else
+            pending ":redis is not running: #hvals"
+          end
+        end
+
+        describe "sorted sets" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#zadd / zrange" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
+              redis.not_nil!.zadd("myzset", [1, "uno"]).should eq(1)
+              redis.not_nil!.zadd("myzset", 2, "two", 3, "three").should eq(2)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
+            end
+          else
+            pending ":redis is not running: #zadd / zrange"
+          end
+
+          if redis_is_running
+            it "#zadd / zrange with xx" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
+              redis.not_nil!.zadd("myzset", 11, "one", xx: true).should eq(0)
+              redis.not_nil!.zadd("myzset", 2, "two", xx: true).should eq(0)
+              redis.not_nil!.zadd("myzset", 3, "three", xx: false).should eq(1)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3", "one", "11"])
+            end
+          else
+            pending ":redis is not running: #zadd / zrange with xx"
+          end
+
+          if redis_is_running
+            it "#zadd / zrange with nx" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one").should eq(1)
+              redis.not_nil!.zadd("myzset", 11, "one", nx: true).should eq(0)
+              redis.not_nil!.zadd("myzset", 2, "two", nx: true).should eq(1)
+              redis.not_nil!.zadd("myzset", 3, "three", nx: false).should eq(1)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "two", "2", "three", "3"])
+            end
+          else
+            pending ":redis is not running: #zadd / zrange with nx"
+          end
+
+          if redis_is_running
+            it "#zadd / zrange with ch" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", ch: true).should eq(1)
+              redis.not_nil!.zadd("myzset", 11, "one", ch: true).should eq(1)
+              redis.not_nil!.zadd("myzset", 2, "two", ch: true).should eq(1)
+              redis.not_nil!.zadd("myzset", 3, "three", ch: false).should eq(1)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3", "one", "11"])
+            end
+          else
+            pending ":redis is not running: #zadd / zrange with ch"
+          end
+
+          if redis_is_running
+            it "#zadd / zrange with incr" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", incr: true).should eq("1")
+              redis.not_nil!.zadd("myzset", 11, "one", incr: true).should eq("12")
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "12"])
+            end
+          else
+            pending ":redis is not running: #zadd / zrange with incr"
+          end
+
+          if redis_is_running
+            it "#zrangebylex" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+              redis.not_nil!.zrangebylex("myzset", "-", "[c").should eq(["a", "b", "c"])
+              redis.not_nil!.zrangebylex("myzset", "-", "(c").should eq(["a", "b"])
+              redis.not_nil!.zrangebylex("myzset", "[aaa", "(g").should eq(["b", "c", "d", "e", "f"])
+              redis.not_nil!.zrangebylex("myzset", "[aaa", "(g", limit: [0, 4]).should eq(["b", "c", "d", "e"])
+            end
+          else
+            pending ":redis is not running: #zrangebylex"
+          end
+
+          if redis_is_running
+            it "#zrangebyscore" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrangebyscore("myzset", "-inf", "+inf").should eq(["one", "two", "three"])
+              redis.not_nil!.zrangebyscore("myzset", "-inf", "+inf", limit: [0, 2]).should eq(["one", "two"])
+            end
+          else
+            pending ":redis is not running: #zrangebyscore"
+          end
+
+          if redis_is_running
+            it "#zrevrange" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrevrange("myzset", 0, -1).should eq(["three", "two", "one"])
+              redis.not_nil!.zrevrange("myzset", 2, 3).should eq(["one"])
+              redis.not_nil!.zrevrange("myzset", -2, -1).should eq(["two", "one"])
+            end
+          else
+            pending ":redis is not running: #zrevrange"
+          end
+
+          if redis_is_running
+            it "#zrevrangebylex" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+              redis.not_nil!.zrevrangebylex("myzset", "[c", "-").should eq(["c", "b", "a"])
+              redis.not_nil!.zrevrangebylex("myzset", "(c", "-").should eq(["b", "a"])
+              redis.not_nil!.zrevrangebylex("myzset", "(g", "[aaa").should eq(["f", "e", "d", "c", "b"])
+              redis.not_nil!.zrevrangebylex("myzset", "+", "-", limit: [1, 1]).should eq(["f"])
+            end
+          else
+            pending ":redis is not running: #zrevrangebylex"
+          end
+
+          if redis_is_running
+            it "#zrevrangebyscore" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrevrangebyscore("myzset", "+inf", "-inf").should eq(["three", "two", "one"])
+              redis.not_nil!.zrevrangebyscore("myzset", "+inf", "-inf", limit: [0, 2]).should eq(["three", "two"])
+            end
+          else
+            pending ":redis is not running: #zrevrangebyscore"
+          end
+
+          if redis_is_running
+            it "#zscore" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 2, "two")
+              redis.not_nil!.zscore("myzset", "two").should eq("2")
+            end
+          else
+            pending ":redis is not running: #zscore"
+          end
+
+          if redis_is_running
+            it "#zcard" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 2, "two", 3, "three")
+              redis.not_nil!.zcard("myzset").should eq(2)
+            end
+          else
+            pending ":redis is not running: #zcard"
+          end
+
+          if redis_is_running
+            it "#zcount" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zcount("myzset", "-inf", "+inf").should eq(3)
+              redis.not_nil!.zcount("myzset", "(1", "3").should eq(2)
+            end
+          else
+            pending ":redis is not running: #zcount"
+          end
+
+          if redis_is_running
+            it "#zlexcount" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+              redis.not_nil!.zlexcount("myzset", "-", "+").should eq(7)
+              redis.not_nil!.zlexcount("myzset", "[b", "[f").should eq(5)
+            end
+          else
+            pending ":redis is not running: #zlexcount"
+          end
+
+          if redis_is_running
+            it "#zrank" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrank("myzset", "one").should eq(0)
+              redis.not_nil!.zrank("myzset", "three").should eq(2)
+              redis.not_nil!.zrank("myzset", "four").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #zrank"
+          end
+
+          describe "zscan" do
+            if redis_is_running
+              it "no options" do
+                redis.not_nil!.del("myset")
+                redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+                new_cursor, keys = redis.not_nil!.zscan("myzset", 0)
+                new_cursor.should eq("0")
+                keys.should eq(["one", "1", "two", "2", "three", "3"])
+              end
+            else
+              pending ":redis is not running: no options"
+            end
+
+            if redis_is_running
+              it "with match" do
+                redis.not_nil!.del("myzset")
+                redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+                new_cursor, keys = redis.not_nil!.zscan("myzset", 0, "t*")
+                new_cursor.should eq("0")
+                keys.is_a?(Array).should be_true
+                # extract odd elements for keys because zscan returns (key, val) as a single list
+                keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+                keys.should eq(["two", "three"])
+              end
+            else
+              pending ":redis is not running: with match"
+            end
+
+            # pending: zscan doesn't handle COUNT strictly
+            # it "#zscan with match and count" do
+            # end
+
+            if redis_is_running
+              it "with match and count at once" do
+                redis.not_nil!.del("myzset")
+                redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+                new_cursor, keys = redis.not_nil!.zscan("myzset", 0, "t*", 1024)
+                new_cursor.should eq("0")
+                keys.is_a?(Array).should be_true
+                # extract odd elements for keys because zscan returns (key, val) as a single list
+                keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+                keys.should eq(["two", "three"])
+              end
+            else
+              pending ":redis is not running: with match and count at once"
+            end
+          end
+
+          if redis_is_running
+            it "#zrevrank" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrevrank("myzset", "one").should eq(2)
+              redis.not_nil!.zrevrank("myzset", "three").should eq(0)
+              redis.not_nil!.zrevrank("myzset", "four").should eq(nil)
+            end
+          else
+            pending ":redis is not running: #zrevrank"
+          end
+
+          if redis_is_running
+            it "#zincrby" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one")
+              redis.not_nil!.zincrby("myzset", 2, "one").should eq("3")
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "3"])
+            end
+          else
+            pending ":redis is not running: #zincrby"
+          end
+
+          if redis_is_running
+            it "#zrem" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zrem("myzset", "two").should eq(1)
+              redis.not_nil!.zcard("myzset").should eq(2)
+            end
+          else
+            pending ":redis is not running: #zrem"
+          end
+
+          if redis_is_running
+            it "#zremrangebylex" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 0, "aaaa", 0, "b", 0, "c", 0, "d", 0, "e")
+              redis.not_nil!.zadd("myzset", 0, "foo", 0, "zap", 0, "zip", 0, "ALPHA", 0, "alpha")
+              redis.not_nil!.zremrangebylex("myzset", "[alpha", "[omega")
+              redis.not_nil!.zrange("myzset", 0, -1).should eq(["ALPHA", "aaaa", "zap", "zip"])
+            end
+          else
+            pending ":redis is not running: #zremrangebylex"
+          end
+
+          if redis_is_running
+            it "#zremrangebyrank" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zremrangebyrank("myzset", 0, 1).should eq(2)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3"])
+            end
+          else
+            pending ":redis is not running: #zremrangebyrank"
+          end
+
+          if redis_is_running
+            it "#zremrangebyscore" do
+              redis.not_nil!.del("myzset")
+              redis.not_nil!.zadd("myzset", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zremrangebyscore("myzset", "-inf", "(2").should eq(1)
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3"])
+            end
+          else
+            pending ":redis is not running: #zremrangebyscore"
+          end
+
+          if redis_is_running
+            it "#zinterstore" do
+              redis.not_nil!.del("zset1", "zset2", "zset3")
+              redis.not_nil!.zadd("zset1", 1, "one", 2, "two")
+              redis.not_nil!.zadd("zset2", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zinterstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(2)
+              redis.not_nil!.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "two", "10"])
+            end
+          else
+            pending ":redis is not running: #zinterstore"
+          end
+
+          if redis_is_running
+            it "#zunionstore" do
+              redis.not_nil!.del("zset1", "zset2", "zset3")
+              redis.not_nil!.zadd("zset1", 1, "one", 2, "two")
+              redis.not_nil!.zadd("zset2", 1, "one", 2, "two", 3, "three")
+              redis.not_nil!.zunionstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(3)
+              redis.not_nil!.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "three", "9", "two", "10"])
+            end
+          else
+            pending ":redis is not running: #zunionstore"
+          end
+        end
+
+        describe "#pipelined" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "executes the commands in the block and returns the results" do
+              futures = [] of Redis::Future
+              results = redis.not_nil!.pipelined do |pipeline|
+                pipeline.set("foo", "new value")
+                futures << pipeline.get("foo")
+              end
+              results[1].should eq("new value")
+              futures[0].value.should eq("new value")
+
+              _client_traces, server_traces = FindJson.from_io(memory)
+              server_traces[0]["spans"][0]["name"].should eq "Redis: SET #{[namespace, "foo"].compact.join("::")}"
+              server_traces[2]["spans"][0]["name"].should eq "Redis::Future#value="
+              server_traces[2]["spans"][0]["attributes"]["db.redis.future.value"].should eq "OK"
+              server_traces[2]["spans"][0]["parentSpanId"].should eq server_traces[0]["spans"][0]["spanId"]
+              server_traces[3]["spans"][0]["attributes"]["db.redis.future.value"].should eq "new value"
+              server_traces[3]["spans"][0]["parentSpanId"].should eq server_traces[1]["spans"][0]["spanId"]
+            end
+          else
+            pending ":redis is not running: executes the commands in the block and returns the results"
+          end
+
+          if redis_is_running
+            it "raises an exception if we call methods on the Redis object" do
+              redis.not_nil!.pipelined do |_pipeline|
+                expect_raises Redis::Error do
+                  redis.not_nil!.set("foo", "bar")
+                end
+              end
+            end
+          else
+            pending ":redis is not running: raises an exception if we call methods on the Redis object"
+          end
+
+          if redis_is_running
+            it "work with hgetall" do
+              redis.not_nil!.del("myhash")
+              redis.not_nil!.hset("myhash", "a", "123")
+              redis.not_nil!.hset("myhash", "b", "456")
+
+              h = redis.not_nil!.pipelined do |pipeline|
+                pipeline.exists("myhash")
+                pipeline.hgetall("myhash")
+              end
+
+              h.should eq([1, ["a", "123", "b", "456"]])
+            end
+          else
+            pending ":redis is not running: work with hgetall"
+          end
+        end
+
+        describe "hyperloglog" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#pfadd / #pfcount" do
+              redis.not_nil!.del("hll")
+              redis.not_nil!.pfadd("hll", "a", "b", "c", "d", "e", "f", "g").should eq(1)
+              redis.not_nil!.pfcount("hll").should eq(7)
+            end
+          else
+            pending ":redis is not running: #pfadd / #pfcount"
+          end
+
+          if redis_is_running
+            it "#pfmerge" do
+              redis.not_nil!.del("hll1", "hll2", "hll3")
+              redis.not_nil!.pfadd("hll1", "foo", "bar", "zap", "a")
+              redis.not_nil!.pfadd("hll2", "a", "b", "c", "foo")
+              redis.not_nil!.pfmerge("hll3", "hll1", "hll2").should eq("OK")
+              redis.not_nil!.pfcount("hll3").should eq(6)
+            end
+          else
+            pending ":redis is not running: #pfmerge"
+          end
+        end
+
+        describe "#info" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "returns server data" do
+              x = redis.not_nil!.info
+              x.size.should be >= 70
+
+              x = redis.not_nil!.info("cpu")
+              (4..8).should contain(x.size)
+
+              redis.not_nil!.info["redis_version"].should_not be_nil
+            end
+          else
+            pending ":redis is not running: returns server data"
+          end
+        end
+
+        describe "#multi" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "executes the commands in the block and returns the results" do
+              futures = [] of Redis::Future
+              results = redis.not_nil!.multi do |multi|
+                multi.set("foo", "new value")
+                futures << multi.get("foo")
+              end
+              results[1].should eq("new value")
+              # future.not_nil!
+              futures[0].value.should eq("new value")
+            end
+          else
+            pending ":redis is not running: executes the commands in the block and returns the results"
+          end
+
+          if redis_is_running
+            it "does not execute the commands in the block upon #discard" do
+              redis.not_nil!.set("foo", "initial value")
+              results = redis.not_nil!.multi do |multi|
+                multi.set("foo", "new value")
+                multi.discard
+              end
+              redis.not_nil!.get("foo").should eq("initial value")
+              results.should eq([] of Redis::RedisValue)
+            end
+          else
+            pending ":redis is not running: does not execute the commands in the block upon #discard"
+          end
+
+          if redis_is_running
+            it "performs optimistic locking with #watch" do
+              redis.not_nil!.set("foo", "1")
+              current_value = redis.not_nil!.get("foo").not_nil!
+              redis.not_nil!.watch("foo")
+              redis.not_nil!.multi do |multi|
+                other_redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+                other_redis.not_nil!.set("foo", "value set by other client")
+                multi.set("foo", current_value + "2")
+              end
+              redis.not_nil!.get("foo").should eq("value set by other client")
+            end
+          else
+            pending ":redis is not running: performs optimistic locking with #watch"
+          end
+
+          if redis_is_running
+            it "#watch" do
+              redis.not_nil!.set("foo", "1")
+              redis.not_nil!.watch("foo")
+              redis.not_nil!.unwatch
+            end
+          else
+            pending ":redis is not running: #watch"
+          end
+
+          if redis_is_running
+            it "raises an exception if we call methods on the Redis object" do
+              redis.not_nil!.multi do |_multi|
+                expect_raises Redis::Error do
+                  redis.not_nil!.set("foo", "bar")
+                end
+              end
+            end
+          else
+            pending ":redis is not running: raises an exception if we call methods on the Redis object"
+          end
+
+          if redis_is_running
+            it "zadd works in multi" do
+              redis.not_nil!.del("myzset")
+
+              redis.not_nil!.multi do |multi|
+                multi.zadd("myzset", 1.0, "one")
+                multi.zadd("myzset", [1, "uno"])
+                multi.zadd("myzset", 2, "two", 3, "three")
+              end
+
+              redis.not_nil!.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
+            end
+          else
+            pending ":redis is not running: zadd works in multi"
+          end
+        end
+
+        describe "LUA scripting" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          describe "#eval" do
+            if redis_is_running
+              it "executes the LUA script" do
+                keys = ["key1", "key2"] of Redis::RedisValue
+                args = ["first", "second"] of Redis::RedisValue
+                result = redis.not_nil!.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", keys, args)
+                result.should eq(["key1", "key2", "first", "second"])
+              end
+            else
+              pending ":redis is not running: executes the LUA script"
+            end
+
+            if redis_is_running
+              it "handles different return types" do
+                keys = ["key1", "key2"] of Redis::RedisValue
+                args = ["first", "second"] of Redis::RedisValue
+                result = redis.not_nil!.eval("return KEYS[1]", keys, args)
+                result.should eq("key1")
+              end
+            else
+              pending ":redis is not running: handles different return types"
+            end
+          end
+
+          describe "#script_load / #eval_sha" do
+            if redis_is_running
+              it "registers a LUA script and calls it" do
+                sha1 = redis.not_nil!.script_load("return {KEYS[1],ARGV[1]}")
+                keys = ["key1", "key2"] of Redis::RedisValue
+                args = ["first", "second"] of Redis::RedisValue
+                result = redis.not_nil!.evalsha(sha1, keys, args)
+                result.should eq(["key1", "first"])
+              end
+            else
+              pending ":redis is not running: registers a LUA script and calls it"
+            end
+
+            if redis_is_running
+              it "handles different return types" do
+                sha1 = redis.not_nil!.script_load("return KEYS[1]")
+                keys = ["key1", "key2"] of Redis::RedisValue
+                args = ["first", "second"] of Redis::RedisValue
+                result = redis.not_nil!.evalsha(sha1, keys, args)
+                result.should eq("key1")
+              end
+            else
+              pending ":redis is not running: handles different return types"
+            end
+          end
+
+          describe "#script_kill" do
+            if redis_is_running
+              it "kills the currently running LUA script" do
+                begin
+                  redis.not_nil!.script_kill
+                rescue Redis::Error
+                end
+              end
+            else
+              pending ":redis is not running: kills the currently running LUA script"
+            end
+          end
+
+          describe "#script_exists" do
+            if redis_is_running
+              it "checks if the given LUA scripts exist" do
+                sha1 = redis.not_nil!.script_load("return 10")
+                result = redis.not_nil!.script_exists([sha1, "fffffffffffffff"])
+                result.should eq([1, 0])
+              end
+            else
+              pending ":redis is not running: checks if the given LUA scripts exist"
+            end
+          end
+
+          describe "#script_flush" do
+            if redis_is_running
+              it "flushes the LUA script cache" do
+                sha1 = redis.not_nil!.script_load("return 10")
+                redis.not_nil!.script_flush
+                redis.not_nil!.script_exists([sha1]).should eq([0])
+              end
+            else
+              pending ":redis is not running: flushes the LUA script cache"
+            end
+          end
+        end
+
+        describe "#type" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "returns a value's type as a string" do
+              redis.not_nil!.set("foo", 3)
+              redis.not_nil!.type("foo").should eq("string")
+            end
+          else
+            pending ":redis is not running: returns a value's type as a string"
+          end
+        end
+
+        describe "expiry" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#expire" do
+              redis.not_nil!.set("temp", "3")
+              redis.not_nil!.expire("temp", 2).should eq(1)
+            end
+          else
+            pending ":redis is not running: #expire"
+          end
+
+          if redis_is_running
+            it "#expireat" do
+              redis.not_nil!.set("temp", "3")
+              redis.not_nil!.expireat("temp", 1555555555005).should eq(1)
+              redis.not_nil!.ttl("temp").should be > 3000
+            end
+          else
+            pending ":redis is not running: #expireat"
+          end
+
+          if redis_is_running
+            it "#ttl" do
+              redis.not_nil!.set("temp", "9")
+              redis.not_nil!.ttl("temp").should eq(-1)
+              redis.not_nil!.expire("temp", 3)
+              redis.not_nil!.ttl("temp").should eq(3)
+            end
+          else
+            pending ":redis is not running: #ttl"
+          end
+
+          if redis_is_running
+            it "#pexpire" do
+              redis.not_nil!.set("temp", "3")
+              redis.not_nil!.pexpire("temp", 1000).should eq(1)
+            end
+          else
+            pending ":redis is not running: #pexpire"
+          end
+
+          if redis_is_running
+            it "#pexpireat" do
+              redis.not_nil!.set("temp", "3")
+              timeout = Time.utc(2029, 2, 15, 10, 20, 30)
+              redis.not_nil!.pexpireat("temp", timeout.to_unix_ms).should eq(1)
+              redis.not_nil!.pttl("temp").should be > 2990
+            end
+          else
+            pending ":redis is not running: #pexpireat"
+          end
+
+          if redis_is_running
+            it "#pttl" do
+              redis.not_nil!.set("temp", "9")
+              redis.not_nil!.pttl("temp").should eq(-1)
+              redis.not_nil!.pexpire("temp", 3000)
+              redis.not_nil!.pttl("temp").should be > 2990
+            end
+          else
+            pending ":redis is not running: #pttl"
+          end
+
+          if redis_is_running
+            it "#persist" do
+              redis.not_nil!.set("temp", "9")
+              redis.not_nil!.expire("temp", 3)
+              redis.not_nil!.ttl("temp").should eq(3)
+              redis.not_nil!.persist("temp")
+              redis.not_nil!.ttl("temp").should eq(-1)
+            end
+          else
+            pending ":redis is not running: #persist"
+          end
+        end
+
+        describe "publish / subscribe" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#publish" do
+              redis.not_nil!.publish("mychannel", "my message")
+            end
+          else
+            pending ":redis is not running: #publish"
+          end
+
+          if redis_is_running
+            it "#subscribe / #unsubscribe" do
+              callbacks_received = [] of String
+              redis.not_nil!.subscribe("mychannel") do |on|
+                on.subscribe do |channel, subscriptions|
+                  channel.should eq("mychannel")
+                  subscriptions.should eq(1)
+                  callbacks_received << "subscribe"
+
+                  # Send a message to ourselves so that we can test the other callbacks.
+                  # We need a second connection to do so.
+                  Redis.open do |other_redis|
+                    other_redis.not_nil!.publish("mychannel", "just talking to myself")
+                  end
+                end
+
+                on.message do |channel, message|
+                  channel.should eq("mychannel")
+                  message.should eq("just talking to myself")
+                  callbacks_received << "message"
+
+                  # Great, we are done.
+                  redis.not_nil!.unsubscribe("mychannel")
+                end
+
+                on.unsubscribe do |channel, subscriptions|
+                  channel.should eq("mychannel")
+                  subscriptions.should eq(0)
+                  callbacks_received << "unsubscribe"
+                end
+              end
+
+              callbacks_received.should eq(["subscribe", "message", "unsubscribe"])
+            end
+          else
+            pending ":redis is not running: #subscribe / #unsubscribe"
+          end
+
+          if redis_is_running
+            it "can be used after #unsubscribe" do
+              redis.not_nil!.subscribe("mychannel") do |on|
+                on.subscribe do |c, _s|
+                  redis.not_nil!.unsubscribe(c)
+                end
+              end
+              redis.not_nil!.set("temp", "temp1")
+              redis.not_nil!.get("temp").should eq "temp1"
+            end
+          else
+            pending ":redis is not running: can be used after #unsubscribe"
+          end
+
+          if redis_is_running
+            it "use ping in #subscribe" do
+              redis.not_nil!.del("mychannel")
+              res = [] of String
+
+              spawn do
+                redis.not_nil!.subscribe("mychannel") do |on|
+                  on.message do |_channel, message|
+                    res << message
+                    res << redis.not_nil!.ping
+                    redis.not_nil!.unsubscribe("mychannel") if res.size >= 4
+                  end
+                end
+              end
+
+              Redis.new.publish("mychannel", "11")
+              Redis.new.publish("mychannel", "22")
+
+              sleep 0.1
+              res.should eq ["11", "pong", "22", "pong"]
+            end
+          else
+            pending ":redis is not running: use ping in #subscribe"
+          end
+        end
+
+        describe "punsubscribe" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#psubscribe / #punsubscribe" do
+              callbacks_received = [] of String
+
+              redis.not_nil!.psubscribe("otherchan*") do |on|
+                on.psubscribe do |channel_pattern, subscriptions|
+                  channel_pattern.should eq("otherchan*")
+                  subscriptions.should eq(1)
+                  callbacks_received << "psubscribe"
+
+                  # Send a message to ourselves so that we can test the other callbacks.
+                  # We need a second connection to do so.
+                  Redis.open do |other_redis|
+                    other_redis.not_nil!.publish("otherchannel", "hello subscriber")
+                  end
+                end
+
+                on.pmessage do |channel_pattern, channel, message|
+                  channel_pattern.should eq("otherchan*")
+                  channel.should eq("otherchannel")
+                  message.should eq("hello subscriber")
+                  callbacks_received << "pmessage"
+
+                  # Great, we are done.
+                  redis.not_nil!.punsubscribe("otherchan*")
+                end
+
+                on.punsubscribe do |channel_pattern, subscriptions|
+                  channel_pattern.should eq("otherchan*")
+                  subscriptions.should eq(0)
+                  callbacks_received << "punsubscribe"
+                end
+              end
+
+              callbacks_received.should eq(["psubscribe", "pmessage", "punsubscribe"])
+            end
+          else
+            pending ":redis is not running: #psubscribe / #punsubscribe"
+          end
+        end
+
+        describe "OBJECT commands" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#object_refcount" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "Hello", "World")
+              redis.not_nil!.object_refcount("mylist").should eq(1)
+            end
+          else
+            pending ":redis is not running: #object_refcount"
+          end
+
+          if redis_is_running
+            it "#object_encoding" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "Hello", "World")
+              redis.not_nil!.object_encoding("mylist").should eq("quicklist")
+            end
+          else
+            pending ":redis is not running: #object_encoding"
+          end
+
+          if redis_is_running
+            it "#object_idletime" do
+              redis.not_nil!.del("mylist")
+              redis.not_nil!.rpush("mylist", "Hello", "World")
+              redis.not_nil!.object_idletime("mylist").should eq(0)
+            end
+          else
+            pending ":redis is not running: #object_idletime"
+          end
+        end
+
+        describe "GEO commands" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "#geoadd" do
+              redis.not_nil!.geoadd("Nebraska", -96.8308123, 40.8005243, "Lincoln").should eq(1)
+              redis.not_nil!.geoadd("Nebraska", -96.3614327, 41.2915193, "Omaha").should eq(1)
+            end
+          else
+            pending ":redis is not running: #geoadd"
+          end
+
+          if redis_is_running
+            it "#geodist" do
+              redis.not_nil!.geodist("Nebraska", "Lincoln", "Omaha", "mi").should eq("41.8340")
+            end
+          else
+            pending ":redis is not running: #geodist"
+          end
+
+          if redis_is_running
+            it "#geohash" do
+              geohash = redis.not_nil!.geohash("Nebraska", "Lincoln", "Omaha")
+              geohash.should eq(["9z70he9bq80", "9z76zhzsxc0"])
+            end
+          else
+            pending ":redis is not running: #geohash"
+          end
+
+          if redis_is_running
+            it "#geopos" do
+              pos = redis.not_nil!.geopos("Nebraska", "Lincoln")
+              pos.size.should eq(1)
+              pos[0].as(Array(Redis::RedisValue)).size.should eq(2)
+            end
+          else
+            pending ":redis is not running: #geopos"
+          end
+
+          if redis_is_running
+            it "#georadius" do
+              results = redis.not_nil!.georadius("Nebraska", -96.8308123, 40.8005243, 100, "mi")
+              results.size.should eq(2)
+              results.includes?("Lincoln").should be_true
+              results.includes?("Omaha").should be_true
+            end
+          else
+            pending ":redis is not running: #georadius"
+          end
+
+          if redis_is_running
+            it "#georadiusbymember" do
+              results = redis.not_nil!.georadiusbymember("Nebraska", "Lincoln", 100, "mi")
+              results.size.should eq(2)
+              results.includes?("Lincoln").should be_true
+              results.includes?("Omaha").should be_true
+            end
+          else
+            pending ":redis is not running: #georadiusbymember"
+          end
+        end
+
+        describe "large values" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "sends and receives a large value correctly" do
+              redis.not_nil!.del("foo")
+              large_value = "0123456789" * 100_000 # 1 MB
+              redis.not_nil!.set("foo", large_value)
+              redis.not_nil!.get("foo").should eq(large_value)
+            end
+          else
+            pending ":redis is not running: large values"
+          end
+        end
+
+        describe "regression on #keys: compile time error" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          # https://github.com/stefanwille/crystal-redis/issues/100
+          if redis_is_running
+            it "del + key" do
+              redis.not_nil!.set("namespaced::key", 2)
+              redis.not_nil!.keys("namespaced::*").each { |key| redis.not_nil!.del(key) }
+              redis.not_nil!.keys("namespaced::*").size.should eq 0
+
+              redis.not_nil!.del("namespaced::key") # check that this also compile
+            end
+          else
+            pending ":redis is not running: regression on #keys: compile time error"
+          end
+
+          if redis_is_running
+            it "del + keys" do
+              redis.not_nil!.set("namespaced::key", 2)
+              keys = redis.not_nil!.keys("namespaced::*")
+              redis.not_nil!.del(keys)
+              redis.not_nil!.keys("namespaced::*").size.should eq 0
+
+              redis.not_nil!.del(["namespaced::key"]) # check that this also compile
+            end
+          else
+            pending ":redis is not running: regression on #keys: compile time error"
+          end
+        end
+
+        context "namespace" do
+          if redis_is_running
+            redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+          end
+
+          if redis_is_running
+            it "with namespace" do
+              r1 = Redis.new(namespace: "my_namespace")
+              r2 = Redis.new
+              r3 = Redis.new(namespace: "")
+              r2.del("foo")
+              r2.del("my_namespace::foo")
+
+              redis.not_nil!.set("foo", "abc")
+
+              if namespace
+                r1.get("foo").should eq "abc"
+                r2.get("foo").should eq nil
+                r2.get("my_namespace::foo").should eq "abc"
+                r3.get("foo").should eq nil
+                r3.get("my_namespace::foo").should eq "abc"
+              else
+                r1.get("foo").should eq nil
+                r2.get("foo").should eq "abc"
+                r2.get("my_namespace::foo").should eq nil
+                r3.get("foo").should eq "abc"
+                r3.get("my_namespace::foo").should eq nil
+              end
+            end
+          else
+            pending ":redis is not running: namespace"
+          end
+        end
+      end
+    end
+
+    describe "#flush" do
+      if redis_is_running
+        it "flushdb" do
+          Redis.new.flushdb.should eq("OK")
+        end
+      else
+        pending ":redis is not running: flush"
+      end
+
+      if redis_is_running
+        it "flushall" do
+          Redis.new.flushall.should eq("OK")
+        end
+      else
+        pending ":redis is not running: flush"
+      end
+    end
+
+    describe "reconnect option: after losing the connection" do
+      describe "when true" do
+        if redis_is_running
+          it "reconnects" do
+            redis = Redis.new(reconnect: true)
+            redis.not_nil!.close
+            redis.not_nil!.ping.should eq("PONG")
+          end
+        else
+          pending ":redis is not running: reconnect"
+        end
+
+        if redis_is_running
+          it "reconnects for #pipelined" do
+            redis = Redis.new(reconnect: true)
+            redis.not_nil!.close
+            ping_future : Redis::Future? = nil
+            redis.not_nil!.pipelined do |api|
+              ping_future = api.ping
+            end
+            ping_future.not_nil!.value.should eq("PONG")
+          end
+        else
+          pending ":redis is not running: reconnect"
+        end
+
+        if redis_is_running
+          it "reconnects for #multi" do
+            redis = Redis.new(reconnect: true)
+            redis.not_nil!.close
+            ping_future : Redis::Future? = nil
+            redis.not_nil!.multi do |api|
+              ping_future = api.ping
+            end
+            ping_future.not_nil!.value.should eq("PONG")
+          end
+        else
+          pending ":redis is not running: reconnect"
+        end
+      end
+
+      describe "when false" do
+        if redis_is_running
+          it "raises a helpful exception" do
+            redis = Redis.new(reconnect: false)
+            redis.not_nil!.close
+            expect_raises(Redis::ConnectionLostError, "Not connected to Redis server and reconnect=false") do
+              redis.not_nil!.ping
             end
           end
         else
-          pending ":redis is not running: namespace"
+          pending ":redis is not running: reconnect"
         end
-      end
-    end
-  end
-
-  describe "#flush" do
-    if redis_is_running
-      it "flushdb" do
-        Redis.new.flushdb.should eq("OK")
-      end
-    else
-      pending ":redis is not running: flush"
-    end
-
-    if redis_is_running
-      it "flushall" do
-        Redis.new.flushall.should eq("OK")
-      end
-    else
-      pending ":redis is not running: flush"
-    end
-  end
-
-  describe "reconnect option: after losing the connection" do
-    describe "when true" do
-      if redis_is_running
-        it "reconnects" do
-          redis = Redis.new(reconnect: true)
-          redis.not_nil!.close
-          redis.not_nil!.ping.should eq("PONG")
-        end
-      else
-        pending ":redis is not running: reconnect"
-      end
-
-      if redis_is_running
-        it "reconnects for #pipelined" do
-          redis = Redis.new(reconnect: true)
-          redis.not_nil!.close
-          ping_future : Redis::Future? = nil
-          redis.not_nil!.pipelined do |api|
-            ping_future = api.ping
-          end
-          ping_future.not_nil!.value.should eq("PONG")
-        end
-      else
-        pending ":redis is not running: reconnect"
-      end
-
-      if redis_is_running
-        it "reconnects for #multi" do
-          redis = Redis.new(reconnect: true)
-          redis.not_nil!.close
-          ping_future : Redis::Future? = nil
-          redis.not_nil!.multi do |api|
-            ping_future = api.ping
-          end
-          ping_future.not_nil!.value.should eq("PONG")
-        end
-      else
-        pending ":redis is not running: reconnect"
-      end
-    end
-
-    describe "when false" do
-      if redis_is_running
-        it "raises a helpful exception" do
-          redis = Redis.new(reconnect: false)
-          redis.not_nil!.close
-          expect_raises(Redis::ConnectionLostError, "Not connected to Redis server and reconnect=false") do
-            redis.not_nil!.ping
-          end
-        end
-      else
-        pending ":redis is not running: reconnect"
       end
     end
   end

--- a/spec/instrumentation/stefanwille_redis_spec.cr
+++ b/spec/instrumentation/stefanwille_redis_spec.cr
@@ -14,7 +14,6 @@ if_defined?(Redis::Strategy::SingleStatement) do
   describe Redis do
     before_all do
       OpenTelemetry.configure do |config|
-        pp "BANGIN IO BACKEND NOW"
         config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis Driver Test"
         config.service_version = OpenTelemetry::VERSION
         config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)

--- a/spec/instrumentation/stefanwille_redis_spec.cr
+++ b/spec/instrumentation/stefanwille_redis_spec.cr
@@ -83,7 +83,7 @@ if_defined?(Redis::Strategy::SingleStatement) do
       end
 
       it "raises ConnectionError when it cant connect to redis" do
-        expect_raises(Redis::CannotConnectError, "Socket::ConnectError: Error connecting to 'localhost:12345': Connection refused") do
+        expect_raises(Redis::CannotConnectError, /Socket::ConnectError: Error connecting to 'localhost:12345':/) do
           Redis.new(host: "localhost", port: 12345)
         end
       end

--- a/spec/instrumentation/stefanwille_redis_spec.cr
+++ b/spec/instrumentation/stefanwille_redis_spec.cr
@@ -1,0 +1,1650 @@
+require "./stefanwille_redis_spec_helper"
+
+describe Redis do
+  Spec.before_suite do
+    OpenTelemetry.configure do |config|
+      config.service_name = "Crystal OTel Instrumentation - Stefan Wille Redis"
+      config.service_version = "1.0.0"
+      config.exporter = OpenTelemetry::Exporter.new(variant: :stdout)
+    end
+  end
+
+  describe ".new" do
+    it "connects to default host and port" do
+      Redis.new
+    end
+
+    it "connects to specific port and host / disconnects" do
+      Redis.new(host: "localhost", port: 6379)
+    end
+
+    it "connects to a specific database" do
+      redis = Redis.new(host: "localhost", port: 6379, database: 1)
+      redis.url.should eq("redis://localhost:6379/1")
+    end
+
+    it "connects to Unix domain sockets" do
+      redis = Redis.new(unixsocket: TEST_UNIXSOCKET)
+      redis.url.should eq("redis://#{TEST_UNIXSOCKET}/0")
+      redis.ping.should eq "PONG"
+    end
+
+    context "when url argument is given" do
+      it "connects using given URL" do
+        redis = Redis.new(url: "redis://127.0.0.1", host: "host.to.be.ignored", port: 1234)
+        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+    end
+
+    context "when url argument with trailing slash is given" do
+      it "connects using given URL" do
+        redis = Redis.new(url: "redis://127.0.0.1/")
+        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+    end
+
+    it "raises ConnectionError when it cant connect to redis" do
+      expect_raises(Redis::CannotConnectError, "Socket::ConnectError: Error connecting to 'localhost:12345': Connection refused") do
+        Redis.new(host: "localhost", port: 12345)
+      end
+    end
+
+    describe "#close" do
+      it "closes the connection" do
+        redis = Redis.new
+        redis.close
+      end
+
+      it "tolerates a duplicate call" do
+        redis = Redis.new
+        redis.close
+        redis.close
+      end
+    end
+  end
+
+  describe ".open" do
+    it "connects to the Redis server using the given connection params, yields its block and disconnects" do
+      Redis.open(host: "localhost", port: 6379) do |redis|
+        redis.ping
+      end
+    end
+
+    it "connects to the Redis using the given url, yields its block and disconnects" do
+      Redis.open(url: "redis://127.0.0.1") do |redis|
+        redis.ping
+      end
+    end
+  end
+
+  describe "#url" do
+    it "returns the server url" do
+      Redis.open do |redis|
+        redis.url.should eq("redis://localhost:6379/0")
+      end
+      Redis.open(url: "redis://127.0.0.1") do |redis|
+        redis.url.should eq("redis://127.0.0.1:6379/0")
+      end
+    end
+  end
+
+  it "#ping" do
+    Redis.open do |redis|
+      redis.ping.should eq("PONG")
+    end
+  end
+
+  it "#echo" do
+    Redis.open do |redis|
+      redis.echo("Ciao").should eq("Ciao")
+    end
+  end
+
+  it "#quit" do
+    Redis.open do |redis|
+      redis.quit.should eq("OK")
+    end
+  end
+
+  it "#flushdb" do
+    Redis.open do |redis|
+      redis.set("foo", "test")
+      redis.get("foo").should eq("test")
+
+      redis.flushdb.should eq("OK")
+
+      redis.get("foo").should eq(nil)
+    end
+  end
+
+  it "#select" do
+    Redis.open do |redis|
+      redis.select(0).should eq("OK")
+    end
+  end
+
+  it "#auth" do
+    Redis.open do |redis|
+      expect_raises(Redis::Error, "ERR AUTH <password> called without any password configured for the default user") do
+        redis.auth("some-password").should eq("OK")
+      end
+    end
+  end
+
+  {nil, "my_namespace"}.each do |namespace|
+    context "(namespace: #{namespace})" do
+      describe "keys" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#del" do
+          redis.set("foo", "test")
+          redis.del("foo")
+          redis.get("foo").should eq(nil)
+
+          redis.mset({"foo1" => "bar1", "foo2" => "bar2"})
+          redis.del(["foo1", "foo2"]).should eq(2)
+        end
+
+        it "converts keys to strings" do
+          redis.set(:foo, "hello")
+          redis.set(123456, 7)
+          redis.get("foo").should eq("hello")
+          redis.get("123456").should eq("7")
+        end
+
+        it "#rename" do
+          redis.del("foo", "bar")
+          redis.set("foo", "test")
+          redis.rename("foo", "bar")
+          redis.get("bar").should eq("test")
+        end
+
+        it "#renamenx" do
+          redis.set("foo", "Hello")
+          redis.set("bar", "world")
+          redis.renamenx("foo", "bar").should eq(0)
+          redis.get("bar").should eq("world")
+        end
+
+        it "#randomkey" do
+          redis.set("foo", "Hello")
+          redis.randomkey.should_not be_nil
+        end
+
+        it "#exists" do
+          redis.del("foo")
+          redis.exists("foo").should eq(0)
+          redis.set("foo", "test")
+          redis.exists("foo").should eq(1)
+        end
+
+        it "#keys" do
+          redis.set("callmemaybe", 1)
+          redis.keys("callmemaybe").should eq(["callmemaybe"])
+        end
+
+        describe "#sort" do
+          it "sorts the container" do
+            redis.del("mylist")
+            redis.rpush("mylist", "1", "3", "2")
+            redis.sort("mylist").should eq(["1", "2", "3"])
+            redis.sort("mylist", order: "DESC").should eq(["3", "2", "1"])
+          end
+
+          it "limit" do
+            redis.del("mylist")
+            redis.rpush("mylist", "1", "3", "2")
+            redis.sort("mylist", limit: [1, 2]).should eq(["2", "3"])
+          end
+
+          it "by" do
+            redis.del("mylist", "objects", "weights")
+            redis.rpush("mylist", "1", "3", "2")
+            redis.mset({"weight_1" => 1, "weight_2" => 2, "weight_3" => 3})
+            redis.sort("mylist", by: "weights_*").should eq(["1", "2", "3"])
+          end
+
+          it "alpha" do
+            redis.del("mylist")
+            redis.rpush("mylist", "c", "a", "b")
+            redis.sort("mylist", alpha: true).should eq(["a", "b", "c"])
+          end
+
+          it "store" do
+            redis.del("mylist", "destination")
+            redis.rpush("mylist", "1", "3", "2")
+            redis.sort("mylist", store: "destination")
+            redis.lrange("destination", 0, 2).should eq(["1", "2", "3"])
+          end
+        end
+
+        it "#dump / #restore" do
+          Redis.open do |redis|
+            redis.set("foo", "9")
+            serialized_value = redis.dump("foo")
+            # puts "**** ser: #{serialized_value.size}"
+            # redis.del("foo")
+            # redis.restore("foo", 0, serialized_value).should eq("OK")
+            # redis.get("foo").should eq("9")
+            # redis.ttl("foo").should eq(-1)
+          end
+        end
+      end
+
+      describe "select database" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "select database when connect" do
+          redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
+          redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
+
+          redis1.del("test_database")
+          redis2.del("test_database")
+
+          redis1.set("test_database", "1")
+          redis2.set("test_database", "2")
+
+          redis1.get("test_database").should eq "1"
+          redis2.get("test_database").should eq "2"
+        end
+
+        it "select database by command" do
+          redis1 = Redis.new(host: "localhost", port: 6379, database: 1, namespace: namespace || "")
+          redis2 = Redis.new(host: "localhost", port: 6379, database: 2, namespace: namespace || "")
+
+          redis1.del("test_database")
+          redis2.del("test_database")
+
+          redis1.set("test_database", "1")
+          redis2.set("test_database", "2")
+
+          redis.select(1)
+          redis.get("test_database").should eq "1"
+
+          redis.select(2)
+          redis.get("test_database").should eq "2"
+        end
+
+        it "does nothing if current database is the same as given one" do
+          redis.select(2).should eq "OK"
+          redis.select(1).should eq "OK"
+          redis.select(1).should eq "OK"
+          # There is no good way to assert that no command was sent
+        end
+      end
+
+      describe "strings" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#set / #get" do
+          redis.set("foo", "test")
+          redis.get("foo").should eq("test")
+        end
+
+        it "#set options" do
+          redis.set("foo", "test", ex: 7)
+          redis.ttl("foo").should eq(7)
+
+          redis.set("foo", "test", px: 7)
+          redis.ttl("foo").should eq(0)
+
+          redis.set("foo", "test", nx: true)
+
+          redis.set("foo", "test", xx: true)
+        end
+
+        it "#mget" do
+          redis.set("foo1", "test1")
+          redis.set("foo2", "test2")
+          redis.mget("foo1", "foo2").should eq(["test1", "test2"])
+          redis.mget(["foo2", "foo1"]).should eq(["test2", "test1"])
+        end
+
+        it "#mset" do
+          redis.mset({"foo1" => "bar1", "foo2" => "bar2"})
+          redis.get("foo1").should eq("bar1")
+          redis.get("foo2").should eq("bar2")
+        end
+
+        it "#getset" do
+          redis.set("foo", "old")
+          redis.getset("foo", "new").should eq("old")
+          redis.get("foo").should eq("new")
+        end
+
+        it "#setex" do
+          redis.setex("foo", 3, "setexed")
+          redis.get("foo").should eq("setexed")
+        end
+
+        it "#psetex" do
+          redis.psetex("foo", 3000, "psetexed")
+          redis.get("foo").should eq("psetexed")
+        end
+
+        it "#setnx" do
+          redis.del("foo")
+          redis.setnx("foo", "setnxed").should eq(1)
+          redis.get("foo").should eq("setnxed")
+          redis.setnx("foo", "setnxed2").should eq(0)
+          redis.get("foo").should eq("setnxed")
+        end
+
+        it "#msetnx" do
+          redis.del("key1", "key2", "key3")
+          redis.msetnx({"key1": "hello", "key2": "there"}).should eq(1)
+          redis.get("key1").should eq("hello")
+          redis.get("key2").should eq("there")
+          redis.msetnx({"key2": "keep", "key3": "singing"}).should eq(0)
+          redis.get("key1").should eq("hello")
+          redis.get("key2").should eq("there")
+          redis.get("key3").should eq(nil)
+        end
+
+        it "#incr" do
+          redis.set("foo", "3")
+          redis.incr("foo").should eq(4)
+        end
+
+        it "#decr" do
+          redis.set("foo", "3")
+          redis.decr("foo").should eq(2)
+        end
+
+        it "#incrby" do
+          redis.set("foo", "10")
+          redis.incrby("foo", 4).should eq(14)
+        end
+
+        it "#decrby" do
+          redis.set("foo", "10")
+          redis.decrby("foo", 4).should eq(6)
+        end
+
+        it "#incrbyfloat" do
+          redis.set("foo", "10")
+          redis.incrbyfloat("foo", 2.5).should eq("12.5")
+        end
+
+        it "#append" do
+          redis.set("foo", "hello")
+          redis.append("foo", " world")
+          redis.get("foo").should eq("hello world")
+        end
+
+        it "#strlen" do
+          redis.set("foo", "Hello world")
+          redis.strlen("foo").should eq(11)
+          redis.del("foo")
+          redis.strlen("foo").should eq(0)
+        end
+
+        it "#getrange" do
+          redis.set("foo", "This is a string")
+          redis.getrange("foo", 0, 3).should eq("This")
+          redis.getrange("foo", -3, -1).should eq("ing")
+        end
+
+        it "#setrange" do
+          redis.set("foo", "Hello world")
+          redis.setrange("foo", 6, "Redis").should eq(11)
+          redis.get("foo").should eq("Hello Redis")
+        end
+
+        describe "#scan" do
+          it "no options" do
+            redis.set("foo", "Hello world")
+            new_cursor, keys = redis.scan(0)
+            new_cursor = new_cursor.as(String)
+            new_cursor.to_i.should be > 0
+            keys.is_a?(Array).should be_true
+          end
+
+          it "with match" do
+            redis.set("scan.match1", "1")
+            redis.set("scan.match2", "2")
+            new_cursor, keys = redis.scan(0, "scan.match*")
+            new_cursor = new_cursor.as(String)
+            new_cursor.to_i.should be > 0
+            keys.is_a?(Array).should be_true
+            # Here `keys.size` should be 0 or 1 or 2, but I don't know how to test it.
+          end
+
+          it "with match and count" do
+            redis.set("scan.match1", "1")
+            redis.set("scan.match2", "2")
+            new_cursor, keys = redis.scan(0, "scan.match*", 1)
+            new_cursor = new_cursor.as(String)
+            new_cursor.to_i.should be > 0
+            keys.is_a?(Array).should be_true
+            # Here `keys.size` should be 0 or 1, but I don't know how to test it.
+          end
+
+          it "with match and count at once" do
+            redis.set("scan.match1", "1")
+            redis.set("scan.match2", "2")
+            # assumes that current Redis instance has at most 10M entries
+            new_cursor, keys = redis.scan(0, "scan.match*", 10_000_000)
+            new_cursor.should eq("0")
+            array(keys).sort.should eq(["scan.match1", "scan.match2"])
+          end
+        end
+      end
+
+      describe "bit operations" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#bitcount" do
+          redis.set("foo", "foobar")
+          redis.bitcount("foo", 0, 0).should eq(4)
+          redis.bitcount("foo", 1, 1).should eq(6)
+        end
+
+        it "#bitop" do
+          redis.set("key1", "foobar")
+          redis.set("key2", "abcdef")
+          redis.bitop("and", "dest", "key1", "key2").should eq(6)
+          redis.get("dest").should eq("`bc`ab")
+        end
+
+        it "#bitpos" do
+          redis.set("mykey", "0")
+          redis.bitpos("mykey", 1).should eq(2)
+        end
+
+        it "#getbit / #setbit" do
+          redis.del("mykey")
+          redis.setbit("mykey", 7, 1).should eq(0)
+          redis.getbit("mykey", 0).should eq(0)
+          redis.getbit("mykey", 7).should eq(1)
+          redis.getbit("mykey", 100).should eq(0)
+        end
+      end
+
+      describe "lists" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#rpush / #lrange" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello").should eq(1)
+          redis.rpush("mylist", "world").should eq(2)
+          redis.lrange("mylist", 0, 1).should eq(["hello", "world"])
+          redis.rpush("mylist", "snip", "snip").should eq(4)
+        end
+
+        it "#lpush" do
+          redis.del("mylist")
+          redis.lpush("mylist", "hello").should eq(1)
+          redis.lpush("mylist", ["world"]).should eq(2)
+          redis.lrange("mylist", 0, 1).should eq(["world", "hello"])
+          redis.lpush("mylist", "snip", "snip").should eq(4)
+        end
+
+        it "#lpushx" do
+          redis.del("mylist")
+          redis.lpushx("mylist", "hello").should eq(0)
+          redis.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
+          redis.lpush("mylist", "hello")
+          redis.lpushx("mylist", "world").should eq(2)
+          redis.lrange("mylist", 0, 1).should eq(["world", "hello"])
+        end
+
+        it "#rpushx" do
+          redis.del("mylist")
+          redis.rpushx("mylist", "hello").should eq(0)
+          redis.lrange("mylist", 0, 1).should eq([] of Redis::RedisValue)
+          redis.rpush("mylist", "hello")
+          redis.rpushx("mylist", "world").should eq(2)
+          redis.lrange("mylist", 0, 1).should eq(["hello", "world"])
+        end
+
+        it "#lrem" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "my")
+          redis.rpush("mylist", "world")
+          redis.lrem("mylist", 1, "my").should eq(1)
+          redis.lrange("mylist", 0, 1).should eq(["hello", "world"])
+          redis.lrem("mylist", 0, "world").should eq(1)
+          redis.lrange("mylist", 0, 1).should eq(["hello"])
+        end
+
+        it "#llen" do
+          redis.del("mylist")
+          redis.lpush("mylist", "hello")
+          redis.lpush("mylist", "world")
+          redis.llen("mylist").should eq(2)
+        end
+
+        it "#lset" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "world")
+          redis.lset("mylist", 0, "goodbye").should eq("OK")
+          redis.lrange("mylist", 0, 1).should eq(["goodbye", "world"])
+        end
+
+        it "#lindex" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "world")
+          redis.lindex("mylist", 0).should eq("hello")
+          redis.lindex("mylist", 1).should eq("world")
+          redis.lindex("mylist", 2).should eq(nil)
+        end
+
+        it "#lpop" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "world")
+          redis.lpop("mylist").should eq("hello")
+          redis.lpop("mylist").should eq("world")
+          redis.lpop("mylist").should eq(nil)
+        end
+
+        it "#rpop" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "world")
+          redis.rpop("mylist").should eq("world")
+          redis.rpop("mylist").should eq("hello")
+          redis.rpop("mylist").should eq(nil)
+        end
+
+        it "#linsert" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello")
+          redis.rpush("mylist", "world")
+          redis.linsert("mylist", :before, "world", "dear").should eq(3)
+          redis.lrange("mylist", 0, 2).should eq(["hello", "dear", "world"])
+        end
+
+        it "#blpop" do
+          redis.del("mylist")
+          redis.del("myotherlist")
+          redis.rpush("mylist", "hello", "world")
+          redis.blpop(["myotherlist", "mylist"], 1).should eq(["mylist", "hello"])
+        end
+
+        it "#blpop with no data, should not raise" do
+          redis.del("mylist")
+          redis.del("myotherlist")
+          redis.blpop(["myotherlist", "mylist"], 1).should eq([] of String)
+        end
+
+        it "#ltrim" do
+          redis.del("mylist")
+          redis.rpush("mylist", "hello", "good", "world")
+          redis.ltrim("mylist", 0, 0).should eq("OK")
+          redis.lrange("mylist", 0, 2).should eq(["hello"])
+        end
+
+        it "#brpop" do
+          redis.del("mylist")
+          redis.del("myotherlist")
+          redis.rpush("mylist", "hello", "world")
+          redis.brpop(["myotherlist", "mylist"], 1).should eq(["mylist", "world"])
+
+          redis.del("mylist")
+          redis.brpop(["mylist"], 1).should eq([] of String)
+        end
+
+        it "#brpop with no data, should not raise" do
+          redis.del("mylist")
+          redis.del("myotherlist")
+          redis.brpop(["myotherlist", "mylist"], 1).should eq([] of String)
+        end
+
+        it "#rpoplpush" do
+          redis.del("source")
+          redis.del("destination")
+          redis.rpush("source", "a", "b", "c")
+          redis.rpush("destination", "1", "2", "3")
+          redis.rpoplpush("source", "destination")
+          redis.lrange("source", 0, 4).should eq(["a", "b"])
+          redis.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
+        end
+
+        it "#brpoplpush" do
+          redis.del("source")
+          redis.del("destination")
+          redis.rpush("source", "a", "b", "c")
+          redis.rpush("destination", "1", "2", "3")
+          redis.brpoplpush("source", "destination", 0)
+          redis.lrange("source", 0, 4).should eq(["a", "b"])
+          redis.lrange("destination", 0, 4).should eq(["c", "1", "2", "3"])
+
+          # timeout test (#68)
+          redis.del("source")
+          redis.brpoplpush("source", "destination", 1).should eq(nil)
+        end
+      end
+
+      describe "sets" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#sadd / #smembers" do
+          redis.del("myset")
+          redis.sadd("myset", "Hello").should eq(1)
+          redis.sadd("myset", "World").should eq(1)
+          redis.sadd("myset", "World").should eq(0)
+          redis.sadd("myset", ["Foo", "Bar"]).should eq(2)
+          sort(redis.smembers("myset")).should eq(["Bar", "Foo", "Hello", "World"])
+        end
+
+        it "#scard" do
+          redis.del("myset")
+          redis.sadd("myset", "Hello", "World")
+          redis.scard("myset").should eq(2)
+        end
+
+        it "#sismember" do
+          redis.del("key1")
+          redis.sadd("key1", "a")
+          redis.sismember("key1", "a").should eq(1)
+          redis.sismember("key1", "b").should eq(0)
+        end
+
+        it "#srem" do
+          redis.del("myset")
+          redis.sadd("myset", "Hello", "World")
+          redis.srem("myset", "Hello").should eq(1)
+          redis.smembers("myset").should eq(["World"])
+
+          redis.sadd("myset", ["Hello", "World", "Foo"])
+          redis.srem("myset", ["Hello", "Foo"]).should eq(2)
+          redis.smembers("myset").should eq(["World"])
+        end
+
+        it "#sdiff" do
+          redis.del("key1", "key2")
+          redis.sadd("key1", "a", "b", "c")
+          redis.sadd("key2", "c", "d", "e")
+          sort(redis.sdiff("key1", "key2")).should eq(["a", "b"])
+        end
+
+        it "#spop" do
+          redis.del("myset")
+          redis.sadd("myset", "one")
+          redis.spop("myset").should eq("one")
+          redis.smembers("myset").should eq([] of Redis::RedisValue)
+          # Redis 3.0 should have received the "count" argument, but hasn't.
+          #
+          # redis.sadd("myset", "one", "two")
+          # sort(redis.spop("myset", count: 2)).should eq(["one", "two"])
+
+          redis.del("myset")
+          redis.spop("myset").should eq(nil)
+        end
+
+        it "#sdiffstore" do
+          redis.del("key1", "key2", "destination")
+          redis.sadd("key1", "a", "b", "c")
+          redis.sadd("key2", "c", "d", "e")
+          redis.sdiffstore("destination", "key1", "key2").should eq(2)
+          sort(redis.smembers("destination")).should eq(["a", "b"])
+        end
+
+        it "#sinter" do
+          redis.del("key1", "key2")
+          redis.sadd("key1", "a", "b", "c")
+          redis.sadd("key2", "c", "d", "e")
+          redis.sinter("key1", "key2").should eq(["c"])
+        end
+
+        it "#sinterstore" do
+          redis.del("key1", "key2", "destination")
+          redis.sadd("key1", "a", "b", "c")
+          redis.sadd("key2", "c", "d", "e")
+          redis.sinterstore("destination", "key1", "key2").should eq(1)
+          redis.smembers("destination").should eq(["c"])
+        end
+
+        it "#sunion" do
+          redis.del("key1", "key2")
+          redis.sadd("key1", "a", "b")
+          redis.sadd("key2", "c", "d")
+          sort(redis.sunion("key1", "key2")).should eq(["a", "b", "c", "d"])
+        end
+
+        it "#sunionstore" do
+          redis.del("key1", "key2", "destination")
+          redis.sadd("key1", "a", "b")
+          redis.sadd("key2", "c", "d")
+          redis.sunionstore("destination", "key1", "key2").should eq(4)
+          sort(redis.smembers("destination")).should eq(["a", "b", "c", "d"])
+        end
+
+        it "#smove" do
+          redis.del("key1", "key2", "destination")
+          redis.sadd("key1", "a", "b")
+          redis.sadd("key2", "c")
+          redis.smove("key1", "key2", "b").should eq(1)
+          redis.smembers("key1").should eq(["a"])
+          sort(redis.smembers("key2")).should eq(["b", "c"])
+        end
+
+        it "#srandmember" do
+          redis.del("key1", "key2", "destination")
+          redis.sadd("key1", "a")
+          redis.srandmember("key1", 1).should eq(["a"])
+        end
+
+        describe "#sscan" do
+          it "no options" do
+            redis.del("myset")
+            redis.sadd("myset", "a", "b")
+            new_cursor, keys = redis.sscan("myset", 0)
+            new_cursor.should eq("0")
+            sort(keys).should eq(["a", "b"])
+          end
+
+          it "with match" do
+            redis.del("myset")
+            redis.sadd("myset", "foo", "bar", "foo2", "foo3")
+            new_cursor, keys = redis.sscan("myset", 0, "foo*", 2)
+            new_cursor = new_cursor.as(String)
+            keys.is_a?(Array).should be_true
+            array(keys).size.should be > 0
+          end
+
+          it "with match and count" do
+            redis.del("myset")
+            redis.sadd("myset", "foo", "bar", "baz")
+            new_cursor, keys = redis.sscan("myset", 0, "*a*", 1)
+            new_cursor = new_cursor.as(String)
+            new_cursor.to_i.should be > 0
+            keys.is_a?(Array).should be_true
+            # TODO SW: This assertion fails randomly
+            # array(keys).size.should be > 0
+          end
+
+          it "with match and count at once" do
+            redis.del("myset")
+            redis.sadd("myset", "foo", "bar", "baz")
+            new_cursor, keys = redis.sscan("myset", 0, "*a*", 10)
+            new_cursor.should eq("0")
+            keys.is_a?(Array).should be_true
+            array(keys).sort.should eq(["bar", "baz"])
+          end
+        end
+      end
+
+      describe "hashes" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#hset / #hget" do
+          redis.del("myhash")
+          redis.hset("myhash", "a", "434")
+          redis.hget("myhash", "a").should eq("434")
+
+          redis.hget("myhash", "b").should eq("435")
+        end
+
+        it "#hgetall" do
+          redis.del("myhash")
+          redis.hset("myhash", "a", "123")
+          redis.hset("myhash", "b", "456")
+          redis.hgetall("myhash").should eq({"a" => "123", "b" => "456"})
+          redis.del("myhash")
+          redis.hgetall("myhash").should eq({} of String => String)
+        end
+
+        it "#hdel" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "foo")
+          redis.hdel("myhash", "field1").should eq(1)
+          redis.hget("myhash", "field1").should eq(nil)
+        end
+
+        it "#hexists" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "foo")
+          redis.hexists("myhash", "field1").should eq(1)
+          redis.hexists("myhash", "field2").should eq(0)
+        end
+
+        it "#hincrby" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "1")
+          redis.hincrby("myhash", "field1", "3").should eq(4)
+        end
+
+        it "#hincrbyfloat" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "10.50")
+          redis.hincrbyfloat("myhash", "field1", "0.1").should eq("10.6")
+        end
+
+        it "#hkeys" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "1")
+          redis.hset("myhash", "field2", "2")
+          redis.hkeys("myhash").should eq(["field1", "field2"])
+        end
+
+        it "#hlen" do
+          redis.del("myhash")
+          redis.hset("myhash", "field1", "1")
+          redis.hset("myhash", "field2", "2")
+          redis.hlen("myhash").should eq(2)
+        end
+
+        it "#hmget" do
+          redis.del("myhash")
+          redis.hset("myhash", "a", "123")
+          redis.hset("myhash", "b", "456")
+          redis.hmget("myhash", "a", "b").should eq(["123", "456"])
+          redis.hmget("myhash", ["a", "b"]).should eq(["123", "456"])
+        end
+
+        it "#hmset" do
+          redis.del("myhash")
+          redis.hmset("myhash", {"field1": "a", "field2": 2})
+          redis.hget("myhash", "field1").should eq("a")
+          redis.hget("myhash", "field2").should eq("2")
+        end
+
+        describe "#hscan" do
+          redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+          it "no options" do
+            redis.del("myhash")
+            redis.hmset("myhash", {"field1": "a", "field2": "b"})
+            new_cursor, keys = redis.hscan("myhash", 0)
+            new_cursor.should eq("0")
+            keys.should eq({"field1" => "a", "field2" => "b"})
+          end
+
+          it "with match" do
+            redis.del("myhash")
+            redis.hmset("myhash", {"foo": "a", "bar": "b"})
+            new_cursor, keys = redis.hscan("myhash", 0, "f*")
+            new_cursor.should eq("0")
+            keys.should eq({"foo" => "a"})
+          end
+
+          # pending: hscan doesn't handle COUNT strictly
+          # it "#hscan with match and count" do
+          # end
+
+          it "with match and count at once" do
+            redis.del("myhash")
+            redis.hmset("myhash", {"foo": "a", "bar": "b", "baz": "c"})
+            new_cursor, keys = redis.hscan("myhash", 0, "*a*", 1024)
+            new_cursor.should eq("0")
+            pp "*********"
+            pp keys
+            # keys.keys.sort.should eq(["bar", "baz"])
+          end
+        end
+
+        it "#hsetnx" do
+          redis.del("myhash")
+          redis.hsetnx("myhash", "foo", "setnxed").should eq(1)
+          redis.hget("myhash", "foo").should eq("setnxed")
+          redis.hsetnx("myhash", "foo", "setnxed2").should eq(0)
+          redis.hget("myhash", "foo").should eq("setnxed")
+        end
+
+        it "#hvals" do
+          redis.del("myhash")
+          redis.hset("myhash", "a", "123")
+          redis.hset("myhash", "b", "456")
+          redis.hvals("myhash").should eq(["123", "456"])
+        end
+      end
+
+      describe "sorted sets" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#zadd / zrange" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one").should eq(1)
+          redis.zadd("myzset", [1, "uno"]).should eq(1)
+          redis.zadd("myzset", 2, "two", 3, "three").should eq(2)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
+        end
+
+        it "#zadd / zrange with xx" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one").should eq(1)
+          redis.zadd("myzset", 11, "one", xx: true).should eq(0)
+          redis.zadd("myzset", 2, "two", xx: true).should eq(0)
+          redis.zadd("myzset", 3, "three", xx: false).should eq(1)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3", "one", "11"])
+        end
+
+        it "#zadd / zrange with nx" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one").should eq(1)
+          redis.zadd("myzset", 11, "one", nx: true).should eq(0)
+          redis.zadd("myzset", 2, "two", nx: true).should eq(1)
+          redis.zadd("myzset", 3, "three", nx: false).should eq(1)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "two", "2", "three", "3"])
+        end
+
+        it "#zadd / zrange with ch" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", ch: true).should eq(1)
+          redis.zadd("myzset", 11, "one", ch: true).should eq(1)
+          redis.zadd("myzset", 2, "two", ch: true).should eq(1)
+          redis.zadd("myzset", 3, "three", ch: false).should eq(1)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3", "one", "11"])
+        end
+
+        it "#zadd / zrange with incr" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", incr: true).should eq("1")
+          redis.zadd("myzset", 11, "one", incr: true).should eq("12")
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "12"])
+        end
+
+        it "#zrangebylex" do
+          redis.del("myzset")
+          redis.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+          redis.zrangebylex("myzset", "-", "[c").should eq(["a", "b", "c"])
+          redis.zrangebylex("myzset", "-", "(c").should eq(["a", "b"])
+          redis.zrangebylex("myzset", "[aaa", "(g").should eq(["b", "c", "d", "e", "f"])
+          redis.zrangebylex("myzset", "[aaa", "(g", limit: [0, 4]).should eq(["b", "c", "d", "e"])
+        end
+
+        it "#zrangebyscore" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrangebyscore("myzset", "-inf", "+inf").should eq(["one", "two", "three"])
+          redis.zrangebyscore("myzset", "-inf", "+inf", limit: [0, 2]).should eq(["one", "two"])
+        end
+
+        it "#zrevrange" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrevrange("myzset", 0, -1).should eq(["three", "two", "one"])
+          redis.zrevrange("myzset", 2, 3).should eq(["one"])
+          redis.zrevrange("myzset", -2, -1).should eq(["two", "one"])
+        end
+
+        it "#zrevrangebylex" do
+          redis.del("myzset")
+          redis.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+          redis.zrevrangebylex("myzset", "[c", "-").should eq(["c", "b", "a"])
+          redis.zrevrangebylex("myzset", "(c", "-").should eq(["b", "a"])
+          redis.zrevrangebylex("myzset", "(g", "[aaa").should eq(["f", "e", "d", "c", "b"])
+          redis.zrevrangebylex("myzset", "+", "-", limit: [1, 1]).should eq(["f"])
+        end
+
+        it "#zrevrangebyscore" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrevrangebyscore("myzset", "+inf", "-inf").should eq(["three", "two", "one"])
+          redis.zrevrangebyscore("myzset", "+inf", "-inf", limit: [0, 2]).should eq(["three", "two"])
+        end
+
+        it "#zscore" do
+          redis.del("myzset")
+          redis.zadd("myzset", 2, "two")
+          redis.zscore("myzset", "two").should eq("2")
+        end
+
+        it "#zcard" do
+          redis.del("myzset")
+          redis.zadd("myzset", 2, "two", 3, "three")
+          redis.zcard("myzset").should eq(2)
+        end
+
+        it "#zcount" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zcount("myzset", "-inf", "+inf").should eq(3)
+          redis.zcount("myzset", "(1", "3").should eq(2)
+        end
+
+        it "#zlexcount" do
+          redis.del("myzset")
+          redis.zadd("myzset", 0, "a", 0, "b", 0, "c", 0, "d", 0, "e", 0, "f", 0, "g")
+          redis.zlexcount("myzset", "-", "+").should eq(7)
+          redis.zlexcount("myzset", "[b", "[f").should eq(5)
+        end
+
+        it "#zrank" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrank("myzset", "one").should eq(0)
+          redis.zrank("myzset", "three").should eq(2)
+          redis.zrank("myzset", "four").should eq(nil)
+        end
+
+        describe "zscan" do
+          it "no options" do
+            redis.del("myset")
+            redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+            new_cursor, keys = redis.zscan("myzset", 0)
+            new_cursor.should eq("0")
+            keys.should eq(["one", "1", "two", "2", "three", "3"])
+          end
+
+          it "with match" do
+            redis.del("myzset")
+            redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+            new_cursor, keys = redis.zscan("myzset", 0, "t*")
+            new_cursor.should eq("0")
+            keys.is_a?(Array).should be_true
+            # extract odd elements for keys because zscan returns (key, val) as a single list
+            keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+            keys.should eq(["two", "three"])
+          end
+
+          # pending: zscan doesn't handle COUNT strictly
+          # it "#zscan with match and count" do
+          # end
+
+          it "with match and count at once" do
+            redis.del("myzset")
+            redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+            new_cursor, keys = redis.zscan("myzset", 0, "t*", 1024)
+            new_cursor.should eq("0")
+            keys.is_a?(Array).should be_true
+            # extract odd elements for keys because zscan returns (key, val) as a single list
+            keys = array(keys).in_groups_of(2).map(&.first.not_nil!)
+            keys.should eq(["two", "three"])
+          end
+        end
+
+        it "#zrevrank" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrevrank("myzset", "one").should eq(2)
+          redis.zrevrank("myzset", "three").should eq(0)
+          redis.zrevrank("myzset", "four").should eq(nil)
+        end
+
+        it "#zincrby" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one")
+          redis.zincrby("myzset", 2, "one").should eq("3")
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "3"])
+        end
+
+        it "#zrem" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zrem("myzset", "two").should eq(1)
+          redis.zcard("myzset").should eq(2)
+        end
+
+        it "#zremrangebylex" do
+          redis.del("myzset")
+          redis.zadd("myzset", 0, "aaaa", 0, "b", 0, "c", 0, "d", 0, "e")
+          redis.zadd("myzset", 0, "foo", 0, "zap", 0, "zip", 0, "ALPHA", 0, "alpha")
+          redis.zremrangebylex("myzset", "[alpha", "[omega")
+          redis.zrange("myzset", 0, -1).should eq(["ALPHA", "aaaa", "zap", "zip"])
+        end
+
+        it "#zremrangebyrank" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zremrangebyrank("myzset", 0, 1).should eq(2)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["three", "3"])
+        end
+
+        it "#zremrangebyscore" do
+          redis.del("myzset")
+          redis.zadd("myzset", 1, "one", 2, "two", 3, "three")
+          redis.zremrangebyscore("myzset", "-inf", "(2").should eq(1)
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["two", "2", "three", "3"])
+        end
+
+        it "#zinterstore" do
+          redis.del("zset1", "zset2", "zset3")
+          redis.zadd("zset1", 1, "one", 2, "two")
+          redis.zadd("zset2", 1, "one", 2, "two", 3, "three")
+          redis.zinterstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(2)
+          redis.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "two", "10"])
+        end
+
+        it "#zunionstore" do
+          redis.del("zset1", "zset2", "zset3")
+          redis.zadd("zset1", 1, "one", 2, "two")
+          redis.zadd("zset2", 1, "one", 2, "two", 3, "three")
+          redis.zunionstore("zset3", ["zset1", "zset2"], weights: [2, 3]).should eq(3)
+          redis.zrange("zset3", 0, -1, with_scores: true).should eq(["one", "5", "three", "9", "two", "10"])
+        end
+      end
+
+      describe "#pipelined" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "executes the commands in the block and returns the results" do
+          futures = [] of Redis::Future
+          results = redis.pipelined do |pipeline|
+            pipeline.set("foo", "new value")
+            futures << pipeline.get("foo")
+          end
+          results[1].should eq("new value")
+          futures[0].value.should eq("new value")
+        end
+
+        it "raises an exception if we call methods on the Redis object" do
+          redis.pipelined do |pipeline|
+            expect_raises Redis::Error do
+              redis.set("foo", "bar")
+            end
+          end
+        end
+
+        it "work with hgetall" do
+          redis.del("myhash")
+          redis.hset("myhash", "a", "123")
+          redis.hset("myhash", "b", "456")
+
+          h = redis.pipelined do |pipeline|
+            pipeline.exists("myhash")
+            pipeline.hgetall("myhash")
+          end
+
+          h.should eq([1, ["a", "123", "b", "456"]])
+        end
+      end
+
+      describe "hyperloglog" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#pfadd / #pfcount" do
+          redis.del("hll")
+          redis.pfadd("hll", "a", "b", "c", "d", "e", "f", "g").should eq(1)
+          redis.pfcount("hll").should eq(7)
+        end
+
+        it "#pfmerge" do
+          redis.del("hll1", "hll2", "hll3")
+          redis.pfadd("hll1", "foo", "bar", "zap", "a")
+          redis.pfadd("hll2", "a", "b", "c", "foo")
+          redis.pfmerge("hll3", "hll1", "hll2").should eq("OK")
+          redis.pfcount("hll3").should eq(6)
+        end
+      end
+
+      describe "#info" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+        it "returns server data" do
+          x = redis.info
+          x.size.should be >= 70
+
+          x = redis.info("cpu")
+          (4..8).should contain(x.size)
+
+          redis.info["redis_version"].should_not be_nil
+        end
+      end
+
+      describe "#multi" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "executes the commands in the block and returns the results" do
+          futures = [] of Redis::Future
+          results = redis.multi do |multi|
+            multi.set("foo", "new value")
+            futures << multi.get("foo")
+          end
+          results[1].should eq("new value")
+          # future.not_nil!
+          futures[0].value.should eq("new value")
+        end
+
+        it "does not execute the commands in the block upon #discard" do
+          redis.set("foo", "initial value")
+          results = redis.multi do |multi|
+            multi.set("foo", "new value")
+            multi.discard
+          end
+          redis.get("foo").should eq("initial value")
+          results.should eq([] of Redis::RedisValue)
+        end
+
+        it "performs optimistic locking with #watch" do
+          redis.set("foo", "1")
+          current_value = redis.get("foo").not_nil!
+          redis.watch("foo")
+          results = redis.multi do |multi|
+            other_redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+            other_redis.set("foo", "value set by other client")
+            multi.set("foo", current_value + "2")
+          end
+          redis.get("foo").should eq("value set by other client")
+        end
+
+        it "#watch" do
+          redis.set("foo", "1")
+          redis.watch("foo")
+          redis.unwatch
+        end
+
+        it "raises an exception if we call methods on the Redis object" do
+          redis.multi do |multi|
+            expect_raises Redis::Error do
+              redis.set("foo", "bar")
+            end
+          end
+        end
+
+        it "zadd works in multi" do
+          futures = [] of Redis::Future
+          redis.del("myzset")
+
+          results = redis.multi do |multi|
+            multi.zadd("myzset", 1.0, "one")
+            multi.zadd("myzset", [1, "uno"])
+            multi.zadd("myzset", 2, "two", 3, "three")
+          end
+
+          redis.zrange("myzset", 0, -1, with_scores: true).should eq(["one", "1", "uno", "1", "two", "2", "three", "3"])
+        end
+      end
+
+      describe "LUA scripting" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        describe "#eval" do
+          it "executes the LUA script" do
+            keys = ["key1", "key2"] of Redis::RedisValue
+            args = ["first", "second"] of Redis::RedisValue
+            result = redis.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", keys, args)
+            result.should eq(["key1", "key2", "first", "second"])
+          end
+
+          it "handles different return types" do
+            keys = ["key1", "key2"] of Redis::RedisValue
+            args = ["first", "second"] of Redis::RedisValue
+            result = redis.eval("return KEYS[1]", keys, args)
+            result.should eq("key1")
+          end
+        end
+
+        describe "#script_load / #eval_sha" do
+          it "registers a LUA script and calls it" do
+            sha1 = redis.script_load("return {KEYS[1],ARGV[1]}")
+            keys = ["key1", "key2"] of Redis::RedisValue
+            args = ["first", "second"] of Redis::RedisValue
+            result = redis.evalsha(sha1, keys, args)
+            result.should eq(["key1", "first"])
+          end
+
+          it "handles different return types" do
+            sha1 = redis.script_load("return KEYS[1]")
+            keys = ["key1", "key2"] of Redis::RedisValue
+            args = ["first", "second"] of Redis::RedisValue
+            result = redis.evalsha(sha1, keys, args)
+            result.should eq("key1")
+          end
+        end
+
+        describe "#script_kill" do
+          it "kills the currently running LUA script" do
+            begin
+              redis.script_kill
+            rescue Redis::Error
+            end
+          end
+        end
+
+        describe "#script_exists" do
+          it "checks if the given LUA scripts exist" do
+            sha1 = redis.script_load("return 10")
+            result = redis.script_exists([sha1, "fffffffffffffff"])
+            result.should eq([1, 0])
+          end
+        end
+
+        describe "#script_flush" do
+          it "flushes the LUA script cache" do
+            sha1 = redis.script_load("return 10")
+            redis.script_flush
+            redis.script_exists([sha1]).should eq([0])
+          end
+        end
+      end
+
+      describe "#type" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "returns a value's type as a string" do
+          redis.set("foo", 3)
+          redis.type("foo").should eq("string")
+        end
+      end
+
+      describe "expiry" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#expire" do
+          redis.set("temp", "3")
+          redis.expire("temp", 2).should eq(1)
+        end
+
+        it "#expireat" do
+          redis.set("temp", "3")
+          redis.expireat("temp", 1555555555005).should eq(1)
+          redis.ttl("temp").should be > 3000
+        end
+
+        it "#ttl" do
+          redis.set("temp", "9")
+          redis.ttl("temp").should eq(-1)
+          redis.expire("temp", 3)
+          redis.ttl("temp").should eq(3)
+        end
+
+        it "#pexpire" do
+          redis.set("temp", "3")
+          redis.pexpire("temp", 1000).should eq(1)
+        end
+
+        it "#pexpireat" do
+          redis.set("temp", "3")
+          timeout = Time.utc(2029, 2, 15, 10, 20, 30)
+          redis.pexpireat("temp", timeout.to_unix_ms).should eq(1)
+          redis.pttl("temp").should be > 2990
+        end
+
+        it "#pttl" do
+          redis.set("temp", "9")
+          redis.pttl("temp").should eq(-1)
+          redis.pexpire("temp", 3000)
+          redis.pttl("temp").should be > 2990
+        end
+
+        it "#persist" do
+          redis.set("temp", "9")
+          redis.expire("temp", 3)
+          redis.ttl("temp").should eq(3)
+          redis.persist("temp")
+          redis.ttl("temp").should eq(-1)
+        end
+      end
+
+      describe "publish / subscribe" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#publish" do
+          redis.publish("mychannel", "my message")
+        end
+
+        it "#subscribe / #unsubscribe" do
+          callbacks_received = [] of String
+          redis.subscribe("mychannel") do |on|
+            on.subscribe do |channel, subscriptions|
+              channel.should eq("mychannel")
+              subscriptions.should eq(1)
+              callbacks_received << "subscribe"
+
+              # Send a message to ourselves so that we can test the other callbacks.
+              # We need a second connection to do so.
+              Redis.open do |other_redis|
+                other_redis.publish("mychannel", "just talking to myself")
+              end
+            end
+
+            on.message do |channel, message|
+              channel.should eq("mychannel")
+              message.should eq("just talking to myself")
+              callbacks_received << "message"
+
+              # Great, we are done.
+              redis.unsubscribe("mychannel")
+            end
+
+            on.unsubscribe do |channel, subscriptions|
+              channel.should eq("mychannel")
+              subscriptions.should eq(0)
+              callbacks_received << "unsubscribe"
+            end
+          end
+
+          callbacks_received.should eq(["subscribe", "message", "unsubscribe"])
+        end
+
+        it "can be used after #unsubscribe" do
+          redis.subscribe("mychannel") do |on|
+            on.subscribe do |c, s|
+              redis.unsubscribe(c)
+            end
+          end
+          redis.set("temp", "temp1")
+          redis.get("temp").should eq "temp1"
+        end
+
+        it "use ping in #subscribe" do
+          redis.del("mychannel")
+          res = [] of String
+
+          spawn do
+            redis.subscribe("mychannel") do |on|
+              on.message do |channel, message|
+                res << message
+                res << redis.ping
+                redis.unsubscribe("mychannel") if res.size >= 4
+              end
+            end
+          end
+
+          Redis.new.publish("mychannel", "11")
+          Redis.new.publish("mychannel", "22")
+
+          sleep 0.1
+          res.should eq ["11", "pong", "22", "pong"]
+        end
+      end
+
+      describe "punsubscribe" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#psubscribe / #punsubscribe" do
+          callbacks_received = [] of String
+
+          redis.psubscribe("otherchan*") do |on|
+            on.psubscribe do |channel_pattern, subscriptions|
+              channel_pattern.should eq("otherchan*")
+              subscriptions.should eq(1)
+              callbacks_received << "psubscribe"
+
+              # Send a message to ourselves so that we can test the other callbacks.
+              # We need a second connection to do so.
+              Redis.open do |other_redis|
+                other_redis.publish("otherchannel", "hello subscriber")
+              end
+            end
+
+            on.pmessage do |channel_pattern, channel, message|
+              channel_pattern.should eq("otherchan*")
+              channel.should eq("otherchannel")
+              message.should eq("hello subscriber")
+              callbacks_received << "pmessage"
+
+              # Great, we are done.
+              redis.punsubscribe("otherchan*")
+            end
+
+            on.punsubscribe do |channel_pattern, subscriptions|
+              channel_pattern.should eq("otherchan*")
+              subscriptions.should eq(0)
+              callbacks_received << "punsubscribe"
+            end
+          end
+
+          callbacks_received.should eq(["psubscribe", "pmessage", "punsubscribe"])
+        end
+      end
+
+      describe "OBJECT commands" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#object_refcount" do
+          redis.del("mylist")
+          redis.rpush("mylist", "Hello", "World")
+          redis.object_refcount("mylist").should eq(1)
+        end
+
+        it "#object_encoding" do
+          redis.del("mylist")
+          redis.rpush("mylist", "Hello", "World")
+          redis.object_encoding("mylist").should eq("quicklist")
+        end
+
+        it "#object_idletime" do
+          redis.del("mylist")
+          redis.rpush("mylist", "Hello", "World")
+          redis.object_idletime("mylist").should eq(0)
+        end
+      end
+
+      describe "GEO commands" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "#geoadd" do
+          redis.geoadd("Nebraska", -96.8308123, 40.8005243, "Lincoln").should eq(1)
+          redis.geoadd("Nebraska", -96.3614327, 41.2915193, "Omaha").should eq(1)
+        end
+
+        it "#geodist" do
+          redis.geodist("Nebraska", "Lincoln", "Omaha", "mi").should eq("41.8340")
+        end
+
+        it "#geohash" do
+          geohash = redis.geohash("Nebraska", "Lincoln", "Omaha")
+          geohash.should eq(["9z70he9bq80", "9z76zhzsxc0"])
+        end
+
+        it "#geopos" do
+          pos = redis.geopos("Nebraska", "Lincoln")
+          pos.size.should eq(1)
+          pos[0].as(Array(Redis::RedisValue)).size.should eq(2)
+        end
+
+        it "#georadius" do
+          results = redis.georadius("Nebraska", -96.8308123, 40.8005243, 100, "mi")
+          results.size.should eq(2)
+          results.includes?("Lincoln").should be_true
+          results.includes?("Omaha").should be_true
+        end
+
+        it "#georadiusbymember" do
+          results = redis.georadiusbymember("Nebraska", "Lincoln", 100, "mi")
+          results.size.should eq(2)
+          results.includes?("Lincoln").should be_true
+          results.includes?("Omaha").should be_true
+        end
+      end
+
+      describe "large values" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "sends and receives a large value correctly" do
+          redis.del("foo")
+          large_value = "0123456789" * 100_000 # 1 MB
+          redis.set("foo", large_value)
+          redis.get("foo").should eq(large_value)
+        end
+      end
+
+      describe "regression on #keys: compile time error" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        # https://github.com/stefanwille/crystal-redis/issues/100
+        it "del + key" do
+          redis.set("namespaced::key", 2)
+          redis.keys("namespaced::*").each { |key| redis.del(key) }
+          redis.keys("namespaced::*").size.should eq 0
+
+          redis.del("namespaced::key") # check that this also compile
+        end
+
+        it "del + keys" do
+          redis.set("namespaced::key", 2)
+          keys = redis.keys("namespaced::*")
+          redis.del(keys)
+          redis.keys("namespaced::*").size.should eq 0
+
+          redis.del(["namespaced::key"]) # check that this also compile
+        end
+      end
+
+      context "namespace" do
+        redis = namespace ? Redis.new(namespace: namespace) : Redis.new
+
+        it "with namespace" do
+          r1 = Redis.new(namespace: "my_namespace")
+          r2 = Redis.new
+          r3 = Redis.new(namespace: "")
+          r2.del("foo")
+          r2.del("my_namespace::foo")
+
+          redis.set("foo", "abc")
+
+          if namespace
+            r1.get("foo").should eq "abc"
+            r2.get("foo").should eq nil
+            r2.get("my_namespace::foo").should eq "abc"
+            r3.get("foo").should eq nil
+            r3.get("my_namespace::foo").should eq "abc"
+          else
+            r1.get("foo").should eq nil
+            r2.get("foo").should eq "abc"
+            r2.get("my_namespace::foo").should eq nil
+            r3.get("foo").should eq "abc"
+            r3.get("my_namespace::foo").should eq nil
+          end
+        end
+      end
+    end
+  end
+
+  describe "#flush" do
+    it "flushdb" do
+      Redis.new.flushdb.should eq("OK")
+    end
+
+    it "flushall" do
+      Redis.new.flushall.should eq("OK")
+    end
+  end
+
+  describe "reconnect option: after losing the connection" do
+    describe "when true" do
+      it "reconnects" do
+        redis = Redis.new(reconnect: true)
+        redis.close
+        redis.ping.should eq("PONG")
+      end
+
+      it "reconnects for #pipelined" do
+        redis = Redis.new(reconnect: true)
+        redis.close
+        ping_future : Redis::Future? = nil
+        redis.pipelined do |api|
+          ping_future = api.ping
+        end
+        ping_future.not_nil!.value.should eq("PONG")
+      end
+
+      it "reconnects for #multi" do
+        redis = Redis.new(reconnect: true)
+        redis.close
+        ping_future : Redis::Future? = nil
+        redis.multi do |api|
+          ping_future = api.ping
+        end
+        ping_future.not_nil!.value.should eq("PONG")
+      end
+    end
+
+    describe "when false" do
+      it "raises a helpful exception" do
+        redis = Redis.new(reconnect: false)
+        redis.close
+        expect_raises(Redis::ConnectionLostError, "Not connected to Redis server and reconnect=false") do
+          redis.ping
+        end
+      end
+    end
+  end
+end

--- a/spec/instrumentation/stefanwille_redis_spec_helper.cr
+++ b/spec/instrumentation/stefanwille_redis_spec_helper.cr
@@ -1,27 +1,29 @@
 require "spec"
 require "redis"
 
-# A poor man's sort for an array of redis values.
-#
-# I don't know how to do this better within Crystal's type system.
-def sort(a)
-  unless a.is_a? Array(Redis::RedisValue)
-    raise "Cannot sort this: #{a.class}"
+if_defined?(Redis::Strategy::SingleStatement) do
+  # A poor man's sort for an array of redis values.
+  #
+  # I don't know how to do this better within Crystal's type system.
+  def sort(a)
+    unless a.is_a? Array(Redis::RedisValue)
+      raise "Cannot sort this: #{a.class}"
+    end
+
+    convert_to_string_array(a).sort
   end
 
-  convert_to_string_array(a).sort
-end
+  def convert_to_string_array(a)
+    a.map(&.to_s)
+  end
 
-def convert_to_string_array(a)
-  a.map(&.to_s)
-end
+  # Same as `sort` except sorting feature
+  def array(a) : Array(String)
+    (a.as(Array(Redis::RedisValue))).map(&.to_s)
+  rescue
+    raise "Cannot convert to Array(Redis::RedisValue): #{a.class}"
+  end
 
-# Same as `sort` except sorting feature
-def array(a) : Array(String)
-  (a.as(Array(Redis::RedisValue))).map(&.to_s)
-rescue
-  raise "Cannot convert to Array(Redis::RedisValue): #{a.class}"
+  TEST_UNIXSOCKET = ENV["CI_UNIXSOCKET"]? || "/tmp/redis.sock"
+  PASSWORD_PORT   = 6380
 end
-
-TEST_UNIXSOCKET = ENV["CI_UNIXSOCKET"]? || "/tmp/redis.sock"
-PASSWORD_PORT   = 6380

--- a/spec/instrumentation/stefanwille_redis_spec_helper.cr
+++ b/spec/instrumentation/stefanwille_redis_spec_helper.cr
@@ -13,7 +13,7 @@ def sort(a)
 end
 
 def convert_to_string_array(a)
-  a.map { |item| item.to_s }
+  a.map(&.to_s)
 end
 
 # Same as `sort` except sorting feature

--- a/spec/instrumentation/stefanwille_redis_spec_helper.cr
+++ b/spec/instrumentation/stefanwille_redis_spec_helper.cr
@@ -1,0 +1,27 @@
+require "spec"
+require "redis"
+
+# A poor man's sort for an array of redis values.
+#
+# I don't know how to do this better within Crystal's type system.
+def sort(a)
+  unless a.is_a? Array(Redis::RedisValue)
+    raise "Cannot sort this: #{a.class}"
+  end
+
+  convert_to_string_array(a).sort
+end
+
+def convert_to_string_array(a)
+  a.map { |item| item.to_s }
+end
+
+# Same as `sort` except sorting feature
+def array(a) : Array(String)
+  (a.as(Array(Redis::RedisValue))).map(&.to_s)
+rescue
+  raise "Cannot convert to Array(Redis::RedisValue): #{a.class}"
+end
+
+TEST_UNIXSOCKET = ENV["CI_UNIXSOCKET"]? || "/tmp/redis.sock"
+PASSWORD_PORT   = 6380

--- a/spec/instrumentation/websocket_spec_helper.cr
+++ b/spec/instrumentation/websocket_spec_helper.cr
@@ -1,4 +1,3 @@
-require "spec"
 require "../spec_helper"
 require "../support/fibers"
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,6 +8,23 @@ end
 class FindJson
   @buffer : String = ""
 
+  def self.from_io(io : IO::Memory)
+    io.rewind
+
+    json_finder = FindJson.new(io.gets_to_end)
+    io.clear
+
+    traces = [] of JSON::Any
+    while json = json_finder.pull_json
+      traces << JSON.parse(json)
+    end
+
+    client_traces = traces.select { |t| t["spans"][0]["kind"] == 3 }
+    server_traces = traces.reject { |t| t["spans"][0]["kind"] == 3 }
+
+    {client_traces, server_traces}
+  end
+
   def initialize(@buffer)
   end
 

--- a/src/ext/tcpsocket.cr
+++ b/src/ext/tcpsocket.cr
@@ -1,0 +1,13 @@
+require "socket"
+
+class TCPSocket
+  getter hostname : String = ""
+
+  # Preserve a hostname, if one is given. Nothing downstream preserves it, and it doesn't
+  # make sense to lose that information. Many of the semantic conventions for various types
+  # of spans really want to have this information.
+  def initialize(host, port, dns_timeout = nil, connect_timeout = nil, blocking = false)
+    @hostname = URI::Punycode.decode(host)
+    previous_def
+  end
+end

--- a/src/ext/tcpsocket.cr
+++ b/src/ext/tcpsocket.cr
@@ -7,7 +7,7 @@ class TCPSocket
   # make sense to lose that information. Many of the semantic conventions for various types
   # of spans really want to have this information.
   def initialize(host, port, dns_timeout = nil, connect_timeout = nil, blocking = false)
-    @hostname = URI::Punycode.decode(host)
+    @hostname = host.to_s
     previous_def
   end
 end

--- a/src/opentelemetry-instrumentation.cr
+++ b/src/opentelemetry-instrumentation.cr
@@ -1,3 +1,4 @@
+require "defined"
 require "opentelemetry-api"
 require "tracer"
 require "./ext/*"

--- a/src/opentelemetry-instrumentation.cr
+++ b/src/opentelemetry-instrumentation.cr
@@ -4,6 +4,5 @@ require "./ext/*"
 require "./opentelemetry-instrumentation/log_backend"
 
 macro finished
-  puts "DOING INSTRUMENTATION REQUIRES"
   require "./opentelemetry/instrumentation/**"
 end

--- a/src/opentelemetry-instrumentation.cr
+++ b/src/opentelemetry-instrumentation.cr
@@ -4,5 +4,6 @@ require "./ext/*"
 require "./opentelemetry-instrumentation/log_backend"
 
 macro finished
+  puts "DOING INSTRUMENTATION REQUIRES"
   require "./opentelemetry/instrumentation/**"
 end

--- a/src/opentelemetry/instrumentation/crystal/db.cr
+++ b/src/opentelemetry/instrumentation/crystal/db.cr
@@ -21,6 +21,7 @@ end
 
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_DB") do
   if_defined?(DB::Statement) do
+    # :nodoc:
     module OpenTelemetry::Instrumentation
       class CrystalDB < OpenTelemetry::Instrumentation::Instrument
         {% begin %}

--- a/src/opentelemetry/instrumentation/crystal/http_client.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_client.cr
@@ -27,6 +27,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_CLIENT") do
   if_defined?(::HTTP::Client) do
     # This exists to record the instrumentation in the OpenTelemetry::Instrumentation::Registry,
     # which may be used by other code/tools to introspect the installed instrumentation.
+    # :nodoc:
     module OpenTelemetry::Instrumentation
       class CrystalHttpClient < OpenTelemetry::Instrumentation::Instrument
       end

--- a/src/opentelemetry/instrumentation/crystal/http_server.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_server.cr
@@ -26,6 +26,7 @@ end
 
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_SERVER") do
   if_defined?(::HTTP::Server) do
+    # :nodoc:
     module OpenTelemetry::Instrumentation
       class CrystalHttpServer < OpenTelemetry::Instrumentation::Instrument
       end

--- a/src/opentelemetry/instrumentation/crystal/http_websocket.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_websocket.cr
@@ -40,6 +40,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
   if_defined?(::HTTP::WebSocket) do
     # This exists to record the instrumentation in the OpenTelemetry::Instrumentation::Registry,
     # which may be used by other code/tools to introspect the installed instrumentation.
+    # :nodoc:
     module OpenTelemetry::Instrumentation
       class CrystalHttpWebSocket < OpenTelemetry::Instrumentation::Instrument
       end
@@ -55,7 +56,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_ping(info)
+        private def handle_ping(info)
           @current_message.write @buffer[0, info.size]
           if info.final
             message = @current_message.to_s
@@ -66,7 +67,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_pong(info)
+        private def handle_pong(info)
           @current_message.write @buffer[0, info.size]
           if info.final
             @on_pong.try &.call(@current_message.to_s)
@@ -75,7 +76,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_text(info)
+        private def handle_text(info)
           @current_message.write buffer_slice(info)
           if info.final
             @on_message.try &.call(@current_message.to_s)
@@ -84,7 +85,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_binary(info)
+        private def handle_binary(info)
           @current_message.write @buffer[0, info.size]
           if info.final
             @on_binary.try &.call(@current_message.to_slice)
@@ -93,7 +94,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_close(info)
+        private def handle_close(info)
           @current_message.write @buffer[0, info.size]
           if info.final
             @current_message.rewind
@@ -115,7 +116,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         end
 
         @[AlwaysInline]
-        def handle_continuation(info)
+        private def handle_continuation(info)
           # TODO: (asterite) I think this is good, but this case wasn't originally handled
         end
 

--- a/src/opentelemetry/instrumentation/crystal/log.cr
+++ b/src/opentelemetry/instrumentation/crystal/log.cr
@@ -27,6 +27,7 @@ end
 
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_LOG") do
   if_defined?(::Log) do
+    # :nodoc:
     module OpenTelemetry::Instrumentation
       class CrystalLog < OpenTelemetry::Instrumentation::Instrument
       end

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -30,9 +30,9 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
     if_version?(Redis, :>=, "0.3.1") do
       class Redis::Connection
         trace("run") do
-          OpenTelemetry.trace.in_span("Redis #{command[0..1]?.join(' ')}") do |span|
+          OpenTelemetry.trace.in_span("Redis #{command[0..1]? ? command[0..1].join(' ') : ""}") do |span|
             span.client!
-            span["net.peer.name"] = @uri.host
+            span["net.peer.name"] = @uri.host.to_s
             span["net.transport"] = case socket = @socket
                                     when UNIXSocket
                                       "Unix"
@@ -43,8 +43,8 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
                                     end
 
             span["db.system"] = "redis"
-            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
-            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+            span["db.statement"] = command.map(&.to_s.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence.to_s
 
             previous_def
           end

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -19,7 +19,7 @@ end
 
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
   # The stefanwille shard doesn't define this constant. This is unfortunate, but it does (currently)
-  # make it convenient to help differentiate between.
+  # make it convenient to help differentiate between the two shards.
   if_defined?(Redis::VERSION) do
     # :nodoc:
     module OpenTelemetry::Instrumentation

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -30,8 +30,6 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
     if_version?(Redis, :>=, "0.3.1") do
       class Redis::Connection
         trace("run") do
-          span_name = command[0..1].join(' ')
-
           OpenTelemetry.trace.in_span("Redis #{command[0..1]?.join(' ')}") do |span|
             span.client!
             span["net.peer.name"] = @uri.host
@@ -41,7 +39,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
                                     when TCPSocket, OpenSSL::SSL::Socket::Client
                                       "ip_tcp"
                                     else
-                                      @socket.class.name # Generic fallback, but is unlikely to happen
+                                      socket.class.name # Generic fallback, but is unlikely to happen
                                     end
 
             span["db.system"] = "redis"

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -13,6 +13,7 @@ require "../instrument"
 #
 # *
 #
+
 struct OpenTelemetry::InstrumentationDocumentation::JGaskinsRedis
 end
 

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -1,0 +1,56 @@
+require "../instrument"
+
+# # OpenTelemetry::Instrumentation::JGaskinsRedis
+#
+# ### Instruments
+#   * 
+#
+# ### Reference: [https://path.to/package_documentation.html](https://path.to/package_documentation.html)
+#
+# Description of the instrumentation provided, including any nuances, caveats, instructions, or warnings.
+#
+# ## Methods Affected
+#
+# * 
+#
+struct OpenTelemetry::InstrumentationDocumentation::JGaskinsRedis
+end
+
+unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
+  # The stefanwille shard doesn't define this constant. This is unfortunate, but it does (currently)
+  # make it convenient to help differentiate between.
+  if_defined?(Redis::VERSION) do
+    # :nodoc:
+    module OpenTelemetry::Instrumentation
+      class JGaskinsRedis < OpenTelemetry::Instrumentation::Instrument
+      end
+    end
+
+    if_version?(Redis, :>=, "0.3.1") do
+      class Redis::Connection
+        trace("run") do
+          span_name = command[0..1].join(' ')
+
+          OpenTelemetry.trace.in_span("Redis #{command[0..1]?.join(' ')}") do |span|
+            span.client!
+            span["net.peer.name"] = @uri.host
+            span["net.transport"] = case socket = @socket
+            when UNIXSocket
+              "Unix"
+            when TCPSocket, OpenSSL::SSL::Socket::Client
+              "ip_tcp"
+            else
+              @socket.class.name # Generic fallback, but is unlikely to happen
+            end
+
+            span["db.system"] = "redis"
+            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+
+            previous_def
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
+++ b/src/opentelemetry/instrumentation/db/jgaskins_redis.cr
@@ -3,7 +3,7 @@ require "../instrument"
 # # OpenTelemetry::Instrumentation::JGaskinsRedis
 #
 # ### Instruments
-#   * 
+#   *
 #
 # ### Reference: [https://path.to/package_documentation.html](https://path.to/package_documentation.html)
 #
@@ -11,7 +11,7 @@ require "../instrument"
 #
 # ## Methods Affected
 #
-# * 
+# *
 #
 struct OpenTelemetry::InstrumentationDocumentation::JGaskinsRedis
 end
@@ -35,13 +35,13 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_JGASKINS_REDIS") do
             span.client!
             span["net.peer.name"] = @uri.host
             span["net.transport"] = case socket = @socket
-            when UNIXSocket
-              "Unix"
-            when TCPSocket, OpenSSL::SSL::Socket::Client
-              "ip_tcp"
-            else
-              @socket.class.name # Generic fallback, but is unlikely to happen
-            end
+                                    when UNIXSocket
+                                      "Unix"
+                                    when TCPSocket, OpenSSL::SSL::Socket::Client
+                                      "ip_tcp"
+                                    else
+                                      @socket.class.name # Generic fallback, but is unlikely to happen
+                                    end
 
             span["db.system"] = "redis"
             span["db.statement"] = command.map(&.inspect_unquoted).join(' ')

--- a/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
+++ b/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
@@ -27,7 +27,6 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
     end
 
     pp "Pass 2"
-    pp Redis::VERSION
 
     if_defined?(Redis::VERSION) do
       pp "GO STEFAN"
@@ -35,8 +34,8 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
       # Monkeypatch a few things so that useful information is available for the spans.
       # TODO: See if the maintainers would like some version of these patches contributed back to the main project.
       class Redis
-        getter database : Int32?
-        getter uri : URI?
+        getter database : Int32? = nil
+        getter uri : URI? = nil
 
         def initialize(@host = "localhost", @port = 6379, @unixsocket : String? = nil, @password : String? = nil,
                        @database : Int32? = nil, url = nil, @ssl = false, @ssl_context : OpenSSL::SSL::Context::Client? = nil,
@@ -61,8 +60,13 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
         end
       end
 
+      class Redis::Connection
+        property database : Int32? = nil
+        property uri : URI? = nil
+      end
+
       class Redis::Future
-        getter trace_parent : OpenTelemetry::Propagation::TraceContext::TraceParent? = nil
+        property trace_parent : OpenTelemetry::Propagation::TraceContext::TraceParent? = nil
       end
 
       class Redis::Strategy::SingleStatement
@@ -89,8 +93,8 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
                                     end
 
             span["db.system"] = "redis"
-            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
-            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+            span["db.statement"] = request.map(&.to_s.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@connection.@uri.try(&.path.presence) || "/")[1..].presence.to_s
 
             previous_def
           end
@@ -99,7 +103,7 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
 
       class Redis::Strategy::Pipeline
         trace("command") do
-          OpenTelemetry.trace.in_span("Redis #{request[0..1]?.join(' ')}") do |span|
+          OpenTelemetry.trace.in_span("Redis #{request[0..1]? ? request[0..1].join(' ') : ""}") do |span|
             span.producer!
             socket = @connection.@socket
             span["net.peer.name"] = case socket
@@ -117,16 +121,18 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
                                     when TCPSocket, OpenSSL::SSL::Socket::Client
                                       "ip_tcp"
                                     else
-                                      @socket.class.name # Generic fallback, but is unlikely to happen
+                                      socket.class.name # Generic fallback, but is unlikely to happen
                                     end
 
             span["db.system"] = "redis"
-            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
-            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+            span["db.statement"] = request.map(&.to_s.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@connection.@uri.try(&.path.presence) || "/")[1..].presence.to_s
 
             future = previous_def
 
-            future.trace_parent = OpenTelemetry::Propagation::TraceContext::TracePrarent.new(span.context)
+            future.trace_parent = OpenTelemetry::Propagation::TraceContext::TraceParent.from_span_context(span.context)
+
+            future
           end
         end
       end
@@ -138,11 +144,15 @@ unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
             parent = OpenTelemetry::Span.build do |pspan|
               pspan.is_recording = false
 
-              pspan.context.trace_id = trace_parent.trace_id
-              pspan.context.span_id = trace_parent.span_id
+              if tptid = trace_parent.try &.trace_id
+                pspan.context.trace_id = tptid
+                span.context.trace_id = tptid
+              end
+              if tpsid = trace_parent.try &.span_id
+                pspan.context.span_id = tpsid
+              end
             end
             span.parent = parent
-            span.context.trace_id = trace_parent.trace_id
 
             previous_def
           end

--- a/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
+++ b/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
@@ -3,7 +3,7 @@ require "../instrument"
 # # OpenTelemetry::Instrumentation::StefanWilleRedis
 #
 # ### Instruments
-#   * 
+#   *
 #
 # ### Reference: [http://stefanwille.github.io/crystal-redis/](http://stefanwille.github.io/crystal-redis/)
 #
@@ -11,46 +11,146 @@ require "../instrument"
 #
 # ## Methods Affected
 #
-# * 
+# *
 #
 struct OpenTelemetry::InstrumentationDocumentation::StefanWilleRedis
 end
 
+pp Redis
+
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
-
+  pp "Pass 1"
   if_defined?(Redis::Strategy::Transaction) do
-
     module OpenTelemetry::Instrumentation
       class InstrumentName < OpenTelemetry::Instrumentation::Instrument
       end
     end
 
-    unless_defined?(Redis::VERSION) do
-      class Redis::Strategy::SingleStatement < Redis::Strategy::Base
-        OpenTelemetry.trace.in_span("Redis #{request[0..1]?.join(' ')}") do |span|
-          span.client!
-          socket = @connection.@socket
-          span["net.peer.name"] = case socket
-          when UNIXSocket
-            socket.path
-          when TCPSocket, OpenSSL::SSL::Socket::Client
-            socket.hostname.presence || socket.remote_address.address
-          else
-            ""
+    pp "Pass 2"
+    pp Redis::VERSION
+
+    if_defined?(Redis::VERSION) do
+      pp "GO STEFAN"
+
+      # Monkeypatch a few things so that useful information is available for the spans.
+      # TODO: See if the maintainers would like some version of these patches contributed back to the main project.
+      class Redis::Connection
+        getter database : Int32?
+        getter uri : URI?
+        @host : String = "localhost"
+        @port : Int32 = 6379
+        @ssl : Bool = false
+        @reconnect : Bool = true
+        @command_timeout : Time::Span? = nil
+
+        def initialize(@host = "localhost", @port = 6379, @unixsocket : String? = nil, @password : String? = nil,
+                       @database : Int32? = nil, url = nil, @ssl = false, @ssl_context : OpenSSL::SSL::Context::Client? = nil,
+                       @dns_timeout : Time::Span? = nil, @connect_timeout : Time::Span? = nil, @reconnect = true, @command_timeout : Time::Span? = nil,
+                       @namespace : String = "")
+          if url
+            @uri = URI.parse(url)
+            path = uri.path
+            @database = path[1..-1].to_i if path && path.size > 1
           end
 
-          span["net.transport"] = case socket
-          when UNIXSocket
-            "Unix"
-          when TCPSocket, OpenSSL::SSL::Socket::Client
-            "ip_tcp"
-          else
-            @socket.class.name # Generic fallback, but is unlikely to happen
-          end
+          previous_def
+        end
 
-          span["db.system"] = "redis"
-          span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
-          span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+        private def connect
+          previous_def
+
+          if cnxn = @connection
+            cnxn.uri = @uri
+            cnxn.database = @database
+          end
+        end
+      end
+
+      class Redis::Future
+        getter trace_parent : OpenTelemetry::Propagation::TraceContext::TraceParent? = nil
+      end
+
+      class Redis::Strategy::SingleStatement
+        trace("command") do
+          OpenTelemetry.trace.in_span("Redis #{request[0..1]?.join(' ')}") do |span|
+            span.client!
+            socket = @connection.@socket
+            span["net.peer.name"] = case socket
+                                    when UNIXSocket
+                                      socket.path
+                                    when TCPSocket, OpenSSL::SSL::Socket::Client
+                                      socket.hostname.presence || socket.remote_address.address
+                                    else
+                                      ""
+                                    end
+
+            span["net.transport"] = case socket
+                                    when UNIXSocket
+                                      "Unix"
+                                    when TCPSocket, OpenSSL::SSL::Socket::Client
+                                      "ip_tcp"
+                                    else
+                                      @socket.class.name # Generic fallback, but is unlikely to happen
+                                    end
+
+            span["db.system"] = "redis"
+            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+
+            previous_def
+          end
+        end
+      end
+
+      class Redis::Strategy::Pipeline
+        trace("command") do
+          OpenTelemetry.trace.in_span("Redis #{request[0..1]?.join(' ')}") do |span|
+            span.producer!
+            socket = @connection.@socket
+            span["net.peer.name"] = case socket
+                                    when UNIXSocket
+                                      socket.path
+                                    when TCPSocket, OpenSSL::SSL::Socket::Client
+                                      socket.hostname.presence || socket.remote_address.address
+                                    else
+                                      ""
+                                    end
+
+            span["net.transport"] = case socket
+                                    when UNIXSocket
+                                      "Unix"
+                                    when TCPSocket, OpenSSL::SSL::Socket::Client
+                                      "ip_tcp"
+                                    else
+                                      @socket.class.name # Generic fallback, but is unlikely to happen
+                                    end
+
+            span["db.system"] = "redis"
+            span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
+            span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+
+            future = previous_def
+
+            future.trace_parent = OpenTelemetry::Propagation::TraceContext::TracePrarent.new(span.context)
+          end
+        end
+      end
+
+      class Redis::Future
+        trace("value=") do
+          OpenTelemetry.trace.in_span("Redis Result Returned") do |span|
+            span.consumer!
+            parent = OpenTelemetry::Span.build do |pspan|
+              pspan.is_recording = false
+
+              pspan.context.trace_id = trace_parent.trace_id
+              pspan.context.span_id = trace_parent.span_id
+            end
+            span.parent = parent
+            span.context.trace_id = trace_parent.trace_id
+
+            previous_def
+          end
         end
       end
     end

--- a/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
+++ b/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
@@ -1,0 +1,58 @@
+require "../instrument"
+
+# # OpenTelemetry::Instrumentation::StefanWilleRedis
+#
+# ### Instruments
+#   * 
+#
+# ### Reference: [http://stefanwille.github.io/crystal-redis/](http://stefanwille.github.io/crystal-redis/)
+#
+# Description of the instrumentation provided, including any nuances, caveats, instructions, or warnings.
+#
+# ## Methods Affected
+#
+# * 
+#
+struct OpenTelemetry::InstrumentationDocumentation::StefanWilleRedis
+end
+
+unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
+
+  if_defined?(Redis::Strategy::Transaction) do
+
+    module OpenTelemetry::Instrumentation
+      class InstrumentName < OpenTelemetry::Instrumentation::Instrument
+      end
+    end
+
+    unless_defined?(Redis::VERSION) do
+      class Redis::Strategy::SingleStatement < Redis::Strategy::Base
+        OpenTelemetry.trace.in_span("Redis #{request[0..1]?.join(' ')}") do |span|
+          span.client!
+          socket = @connection.@socket
+          span["net.peer.name"] = case socket
+          when UNIXSocket
+            socket.path
+          when TCPSocket, OpenSSL::SSL::Socket::Client
+            socket.hostname.presence || socket.remote_address.address
+          else
+            ""
+          end
+
+          span["net.transport"] = case socket
+          when UNIXSocket
+            "Unix"
+          when TCPSocket, OpenSSL::SSL::Socket::Client
+            "ip_tcp"
+          else
+            @socket.class.name # Generic fallback, but is unlikely to happen
+          end
+
+          span["db.system"] = "redis"
+          span["db.statement"] = command.map(&.inspect_unquoted).join(' ')
+          span["db.redis.database_index"] = (@uri.path.presence || "/")[1..].presence
+        end
+      end
+    end
+  end
+end

--- a/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
+++ b/src/opentelemetry/instrumentation/db/stefanwille_redis.cr
@@ -16,21 +16,14 @@ require "../instrument"
 struct OpenTelemetry::InstrumentationDocumentation::StefanWilleRedis
 end
 
-pp Redis
-
 unless_enabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_STEFANWILLE_REDIS") do
-  pp "Pass 1"
   if_defined?(Redis::Strategy::Transaction) do
     module OpenTelemetry::Instrumentation
       class InstrumentName < OpenTelemetry::Instrumentation::Instrument
       end
     end
 
-    pp "Pass 2"
-
-    if_defined?(Redis::VERSION) do
-      pp "GO STEFAN"
-
+    unless_defined?(Redis::VERSION) do
       # Monkeypatch a few things so that useful information is available for the spans.
       # TODO: See if the maintainers would like some version of these patches contributed back to the main project.
       class Redis


### PR DESCRIPTION
This will add Redis support, for both of the Redis shards that I found, to the auto-instrumentation. Since both shards occupy the same namespace, the _specs_ can't be configured to test both at the same time, so the default is to run against the larger and more complex of the two (Stefan Wille's shard).

Specs are borrowed from the specs for the respective shards themselves, in order to confirm full functioning of the shards, with spans being spot-checked on just a few of those specs to ensure that results are what is expected.