### PR TITLE
fix(crystal/http_websocket): variable name changed

### DIFF
--- a/src/opentelemetry/instrumentation/crystal/http_websocket.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_websocket.cr
@@ -234,7 +234,11 @@ unless_disabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
         trace("close") do
           OpenTelemetry.in_span("HTTP::WebSocket do close") do |span|
             span.client!
-            span["close_code"] = close_code.to_s
+            {% if compare_versions(Crystal::VERSION, "1.5.2") < 0 %}
+              span["close_code"] = close_code.to_s
+            {% else %}
+              span["close_code"] = close.to_s
+            {% end %}
             span["message"] = message.to_s
             previous_def
           end


### PR DESCRIPTION
in crystal 1.6

fixes #25 