### PR TITLE
Update http_websocket trace("close") close_code span

### DIFF
--- a/src/opentelemetry/instrumentation/crystal/http_websocket.cr
+++ b/src/opentelemetry/instrumentation/crystal/http_websocket.cr
@@ -237,7 +237,7 @@ unless_disabled?("OTEL_CRYSTAL_DISABLE_INSTRUMENTATION_HTTP_WEBSOCKET") do
             {% if compare_versions(Crystal::VERSION, "1.5.2") < 0 %}
               span["close_code"] = close_code.to_s
             {% else %}
-              span["close_code"] = close.to_s
+              span["close_code"] = code.to_s
             {% end %}
             span["message"] = message.to_s
             previous_def


### PR DESCRIPTION
call to `close` is causing an infinite loop. `close_code` in Crystal version higher than `1.5.2` is called `code`. This PR fixes this infinite recursion issue.